### PR TITLE
Fix Menu keyboard navigation inside nested submenus

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "55.0 kB"
+      "maxSize": "55.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.js",
@@ -46,7 +46,7 @@
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "33.0 kB"
+      "maxSize": "33.25 kB"
     }
   ],
   "ci": {

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -855,16 +855,40 @@ class Menu extends BaseComponent {
   // Keyboard navigation
   // -------------------------------------------------------------------------
 
+  // Items sit either directly in `.menu`, or as a submenu trigger one level deeper
+  // (`.menu > .submenu > .menu-item`). Both are navigable at the same level.
+  protected _getItemsInMenu(menu: Element): HTMLElement[] {
+    return SelectorEngine.find(
+      `:scope > ${SELECTOR_VISIBLE_ITEMS}, :scope > ${SELECTOR_SUBMENU} > ${SELECTOR_VISIBLE_ITEMS}`,
+      menu
+    ).filter(element => isVisible(element))
+  }
+
   protected _selectMenuItem({ key, target }: BootstrapEvent): void {
     const currentMenu = (target as Element).closest(SELECTOR_MENU) || this._menu
-    const items = SelectorEngine.find(`:scope > ${SELECTOR_VISIBLE_ITEMS}`, currentMenu)
-      .filter(element => isVisible(element))
+    const items = this._getItemsInMenu(currentMenu)
 
     if (!items.length) {
       return
     }
 
-    getNextActiveElement(items, target as HTMLElement, key === ARROW_DOWN_KEY, !items.includes(target as HTMLElement)).focus()
+    const nextItem = getNextActiveElement(items, target as HTMLElement, key === ARROW_DOWN_KEY, !items.includes(target as HTMLElement))
+    nextItem.focus()
+    this._closeUnrelatedSubmenus(currentMenu, nextItem)
+  }
+
+  // Moving focus along one level closes the submenus focus left behind, matching
+  // what hover and click already do through `_closeSiblingSubmenus`.
+  protected _closeUnrelatedSubmenus(currentMenu: Element, focusedElement: HTMLElement): void {
+    for (const [submenu] of this._openSubmenus) {
+      const submenuWrapper = submenu.closest(SELECTOR_SUBMENU)
+
+      if (!submenuWrapper || submenuWrapper.parentElement !== currentMenu || submenuWrapper.contains(focusedElement)) {
+        continue
+      }
+
+      this._closeSubmenu(submenu, submenuWrapper)
+    }
   }
 
   protected _handleSubmenuKeydown(event: BootstrapEvent): boolean {
@@ -938,12 +962,12 @@ class Menu extends BaseComponent {
       event.stopPropagation()
 
       const currentMenu = (target as Element).closest(SELECTOR_MENU)!
-      const items = SelectorEngine.find(`:scope > ${SELECTOR_VISIBLE_ITEMS}`, currentMenu)
-        .filter(element => isVisible(element))
+      const items = this._getItemsInMenu(currentMenu)
 
       if (items.length) {
         const targetItem = key === HOME_KEY ? items[0] : items.at(-1)!
         targetItem.focus()
+        this._closeUnrelatedSubmenus(currentMenu, targetItem)
       }
 
       return true
@@ -991,6 +1015,27 @@ class Menu extends BaseComponent {
     }
   }
 
+  // The keydown handler is delegated on both the toggle and `.menu`, and delegation
+  // stops at the innermost match. So for a key pressed inside a submenu panel, or
+  // inside a menu moved to `container`, the toggle is not a sibling of the element
+  // the handler ran on. Ask the open instances which menu owns the event first, and
+  // only then fall back to the sibling and wrapper lookups.
+  protected static _getToggleFromKeydownContext(element: HTMLElement, event: BootstrapEvent): HTMLElement | null {
+    if (element.matches(SELECTOR_DATA_TOGGLE)) {
+      return element
+    }
+
+    for (const instance of Menu._openInstances) {
+      if (instance._element === event.target || instance._menu?.contains(event.target as Node)) {
+        return instance._element
+      }
+    }
+
+    return SelectorEngine.prev(element, SELECTOR_DATA_TOGGLE)[0] as HTMLElement ||
+      SelectorEngine.next(element, SELECTOR_DATA_TOGGLE)[0] as HTMLElement ||
+      SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, event.delegateTarget.parentNode)
+  }
+
   static dataApiKeydownHandler(this: HTMLElement, event: BootstrapEvent): void {
     // Treat contenteditable hosts (e.g. rich-text editors) like inputs so the
     // menu doesn't hijack their arrow keys.
@@ -1012,11 +1057,7 @@ class Menu extends BaseComponent {
       return
     }
 
-    const getToggleButton: any = this.matches(SELECTOR_DATA_TOGGLE) ?
-      this :
-      (SelectorEngine.prev(this, SELECTOR_DATA_TOGGLE)[0] ||
-        SelectorEngine.next(this, SELECTOR_DATA_TOGGLE)[0] ||
-        SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, event.delegateTarget.parentNode))
+    const getToggleButton = Menu._getToggleFromKeydownContext(this, event)
 
     if (!getToggleButton) {
       return

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -197,6 +197,7 @@ class Menu extends BaseComponent {
 
     this._parseResponsivePlacements()
     this._setupSubmenuListeners()
+    this._initSubmenuTriggers()
   }
 
   // Getters
@@ -675,6 +676,26 @@ class Menu extends BaseComponent {
     } else {
       this._closeSiblingSubmenus(submenuWrapper)
       this._openSubmenu(trigger, submenu, submenuWrapper)
+    }
+  }
+
+  // Announce every submenu trigger up front. Waiting until the submenu opens hides
+  // the popup from assistive technology until a user has already found it.
+  protected _initSubmenuTriggers(): void {
+    if (!this._menu) {
+      return
+    }
+
+    for (const trigger of SelectorEngine.find(SELECTOR_SUBMENU_TOGGLE, this._menu)) {
+      if (!SelectorEngine.findOne(SELECTOR_MENU, trigger.parentElement!)) {
+        continue
+      }
+
+      trigger.setAttribute('aria-haspopup', 'true')
+
+      if (!trigger.hasAttribute('aria-expanded')) {
+        trigger.setAttribute('aria-expanded', 'false')
+      }
     }
   }
 

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -901,26 +901,9 @@ class Menu extends BaseComponent {
     const submenuWrapper = (target as Element).closest(SELECTOR_SUBMENU)
     const isSubmenuToggle = (target as Element).matches(SELECTOR_SUBMENU_TOGGLE)
 
-    if ((key === ENTER_KEY || key === SPACE_KEY) && submenuWrapper && isSubmenuToggle) {
-      event.preventDefault()
-      event.stopPropagation()
+    const isOpenKey = key === ENTER_KEY || key === SPACE_KEY || key === enterKey
 
-      const submenu = SelectorEngine.findOne(SELECTOR_MENU, submenuWrapper)
-      if (submenu) {
-        this._closeSiblingSubmenus(submenuWrapper)
-        this._openSubmenu(target as HTMLElement, submenu, submenuWrapper)
-        requestAnimationFrame(() => {
-          const firstItem = SelectorEngine.findOne(SELECTOR_VISIBLE_ITEMS, submenu)
-          if (firstItem) {
-            firstItem.focus()
-          }
-        })
-      }
-
-      return true
-    }
-
-    if (key === enterKey && submenuWrapper && isSubmenuToggle) {
+    if (isOpenKey && submenuWrapper && isSubmenuToggle) {
       event.preventDefault()
       event.stopPropagation()
 

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -4351,7 +4351,7 @@ describe('Menu', () => {
   })
 
   describe('ArrowLeft to close submenu', () => {
-    it('should close the current submenu via _handleSubmenuKeydown on ArrowLeft', () => {
+    it('should close the current submenu on ArrowLeft pressed inside it', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<div>',
@@ -4379,11 +4379,10 @@ describe('Menu', () => {
           expect(submenu.classList.contains('show')).toBeTrue()
 
           subItem.focus()
-          const arrowLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true })
-          Object.defineProperty(arrowLeftEvent, 'target', { value: subItem })
-          const handled = menu._handleSubmenuKeydown(arrowLeftEvent)
+          const arrowLeft = createEvent('keydown', { bubbles: true })
+          arrowLeft.key = 'ArrowLeft'
+          subItem.dispatchEvent(arrowLeft)
 
-          expect(handled).toBeTrue()
           expect(submenu.classList.contains('show')).toBeFalse()
           expect(document.activeElement).toEqual(subTrigger)
           resolve()
@@ -4395,7 +4394,7 @@ describe('Menu', () => {
   })
 
   describe('Escape in submenu', () => {
-    it('should close the current submenu via dataApiKeydownHandler on Escape', () => {
+    it('should close the current submenu on Escape pressed inside it', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<div>',
@@ -4416,6 +4415,7 @@ describe('Menu', () => {
         const subTrigger = fixtureEl.querySelector('#sub-trigger')
         const submenuWrapper = fixtureEl.querySelector('.submenu')
         const submenu = submenuWrapper.querySelector('.menu')
+        const subItem = fixtureEl.querySelector('#sub-item')
         const menu = new Menu(btnMenu)
 
         btnMenu.addEventListener('shown.bs.menu', () => {
@@ -4423,11 +4423,53 @@ describe('Menu', () => {
           expect(submenu.classList.contains('show')).toBeTrue()
           expect(menu._openSubmenus.size).toEqual(1)
 
-          menu._closeSubmenu(submenu, submenuWrapper)
+          subItem.focus()
+          const escape = createEvent('keydown', { bubbles: true })
+          escape.key = 'Escape'
+          subItem.dispatchEvent(escape)
 
           expect(submenu.classList.contains('show')).toBeFalse()
           expect(menu._openSubmenus.size).toEqual(0)
+          expect(document.activeElement).toEqual(subTrigger)
+          // Only the submenu closes — the root menu stays open
           expect(btnMenu).toHaveClass('show')
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should close the whole menu on Escape pressed at the top level', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <a id="top-item" class="menu-item" href="#">Top item</a>',
+          '    <div class="submenu">',
+          '      <button class="menu-item" type="button">Sub</button>',
+          '      <div class="menu">',
+          '        <a class="menu-item" href="#">Sub item</a>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const menuEl = fixtureEl.querySelector('.menu')
+        const topItem = fixtureEl.querySelector('#top-item')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          topItem.focus()
+          const escape = createEvent('keydown', { bubbles: true })
+          escape.key = 'Escape'
+          topItem.dispatchEvent(escape)
+
+          expect(menuEl).not.toHaveClass('show')
+          expect(document.activeElement).toEqual(btnMenu)
           resolve()
         })
 
@@ -4437,7 +4479,7 @@ describe('Menu', () => {
   })
 
   describe('scoped keyboard navigation', () => {
-    it('should scope ArrowDown/ArrowUp to direct children of the current menu level', () => {
+    it('should scope ArrowDown/ArrowUp to the current menu level, including submenu triggers', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<div>',
@@ -4445,7 +4487,7 @@ describe('Menu', () => {
           '  <div class="menu">',
           '    <a id="top-item-1" class="menu-item" href="#">Top 1</a>',
           '    <div class="submenu">',
-          '      <button class="menu-item" type="button">Sub trigger</button>',
+          '      <button id="sub-trigger" class="menu-item" type="button">Sub trigger</button>',
           '      <div class="menu">',
           '        <a id="sub-item-1" class="menu-item" href="#">Sub 1</a>',
           '        <a id="sub-item-2" class="menu-item" href="#">Sub 2</a>',
@@ -4458,19 +4500,347 @@ describe('Menu', () => {
 
         const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
         const topItem1 = fixtureEl.querySelector('#top-item-1')
+        const subTrigger = fixtureEl.querySelector('#sub-trigger')
+        const topItem2 = fixtureEl.querySelector('#top-item-2')
         const menu = new Menu(btnMenu)
 
         btnMenu.addEventListener('shown.bs.menu', () => {
           topItem1.focus()
           expect(document.activeElement).toEqual(topItem1)
 
-          const arrowDown = createEvent('keydown')
+          const arrowDown = createEvent('keydown', { bubbles: true })
           arrowDown.key = 'ArrowDown'
-          topItem1.dispatchEvent(arrowDown)
 
-          setTimeout(() => {
-            resolve()
-          }, 20)
+          // The submenu trigger sits one level deeper in the DOM, but belongs to this level
+          topItem1.dispatchEvent(arrowDown)
+          expect(document.activeElement).toEqual(subTrigger)
+
+          // The submenu's own items are never reached from the parent level
+          subTrigger.dispatchEvent(arrowDown)
+          expect(document.activeElement).toEqual(topItem2)
+
+          const arrowUp = createEvent('keydown', { bubbles: true })
+          arrowUp.key = 'ArrowUp'
+          topItem2.dispatchEvent(arrowUp)
+          expect(document.activeElement).toEqual(subTrigger)
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should skip disabled submenu triggers', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <a id="top-item" class="menu-item" href="#">Top</a>',
+          '    <div class="submenu">',
+          '      <button id="disabled-trigger" class="menu-item" type="button" disabled>Disabled</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Hidden</a></div>',
+          '    </div>',
+          '    <div class="submenu">',
+          '      <button id="enabled-trigger" class="menu-item" type="button">Enabled</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Shown</a></div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const topItem = fixtureEl.querySelector('#top-item')
+        const disabledTrigger = fixtureEl.querySelector('#disabled-trigger')
+        const enabledTrigger = fixtureEl.querySelector('#enabled-trigger')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          topItem.focus()
+
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          topItem.dispatchEvent(arrowDown)
+
+          expect(document.activeElement).toEqual(enabledTrigger)
+          expect(document.activeElement).not.toEqual(disabledTrigger)
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+  })
+
+  describe('keyboard navigation inside open submenus', () => {
+    it('should move focus with ArrowDown/ArrowUp between items of an open submenu', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu">',
+          '      <button id="sub-trigger" class="menu-item" type="button">Sub</button>',
+          '      <div class="menu">',
+          '        <a id="sub-item-1" class="menu-item" href="#">Sub 1</a>',
+          '        <a id="sub-item-2" class="menu-item" href="#">Sub 2</a>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const subTrigger = fixtureEl.querySelector('#sub-trigger')
+        const subItem1 = fixtureEl.querySelector('#sub-item-1')
+        const subItem2 = fixtureEl.querySelector('#sub-item-2')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          subTrigger.click()
+          subItem1.focus()
+
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          subItem1.dispatchEvent(arrowDown)
+          expect(document.activeElement).toEqual(subItem2)
+
+          const arrowUp = createEvent('keydown', { bubbles: true })
+          arrowUp.key = 'ArrowUp'
+          subItem2.dispatchEvent(arrowUp)
+          expect(document.activeElement).toEqual(subItem1)
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should jump to the first and last item of an open submenu with Home and End', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu">',
+          '      <button id="sub-trigger" class="menu-item" type="button">Sub</button>',
+          '      <div class="menu">',
+          '        <a id="sub-first" class="menu-item" href="#">Sub first</a>',
+          '        <a id="sub-middle" class="menu-item" href="#">Sub middle</a>',
+          '        <a id="sub-last" class="menu-item" href="#">Sub last</a>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const subTrigger = fixtureEl.querySelector('#sub-trigger')
+        const subFirst = fixtureEl.querySelector('#sub-first')
+        const subMiddle = fixtureEl.querySelector('#sub-middle')
+        const subLast = fixtureEl.querySelector('#sub-last')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          subTrigger.click()
+          subMiddle.focus()
+
+          const endKey = createEvent('keydown', { bubbles: true })
+          endKey.key = 'End'
+          subMiddle.dispatchEvent(endKey)
+          expect(document.activeElement).toEqual(subLast)
+
+          const homeKey = createEvent('keydown', { bubbles: true })
+          homeKey.key = 'Home'
+          subLast.dispatchEvent(homeKey)
+          expect(document.activeElement).toEqual(subFirst)
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should navigate a third level submenu and walk back up with ArrowLeft', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu">',
+          '      <button id="level-1-trigger" class="menu-item" type="button">Level 1</button>',
+          '      <div class="menu">',
+          '        <div class="submenu">',
+          '          <button id="level-2-trigger" class="menu-item" type="button">Level 2</button>',
+          '          <div class="menu">',
+          '            <a id="level-3-a" class="menu-item" href="#">Level 3 A</a>',
+          '            <a id="level-3-b" class="menu-item" href="#">Level 3 B</a>',
+          '          </div>',
+          '        </div>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const level1Trigger = fixtureEl.querySelector('#level-1-trigger')
+        const level2Trigger = fixtureEl.querySelector('#level-2-trigger')
+        const level2Menu = fixtureEl.querySelector('#level-2-trigger').nextElementSibling
+        const level3A = fixtureEl.querySelector('#level-3-a')
+        const level3B = fixtureEl.querySelector('#level-3-b')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          level1Trigger.click()
+          level2Trigger.click()
+          expect(level2Menu).toHaveClass('show')
+
+          level3A.focus()
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          level3A.dispatchEvent(arrowDown)
+          expect(document.activeElement).toEqual(level3B)
+
+          const arrowLeft = createEvent('keydown', { bubbles: true })
+          arrowLeft.key = 'ArrowLeft'
+          level3B.dispatchEvent(arrowLeft)
+          expect(level2Menu).not.toHaveClass('show')
+          expect(document.activeElement).toEqual(level2Trigger)
+
+          level2Trigger.dispatchEvent(arrowLeft)
+          expect(document.activeElement).toEqual(level1Trigger)
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should close an open sibling submenu when focus moves to another item', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu" id="submenu-1">',
+          '      <button id="trigger-1" class="menu-item" type="button">Submenu 1</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 1</a></div>',
+          '    </div>',
+          '    <div class="submenu" id="submenu-2">',
+          '      <button id="trigger-2" class="menu-item" type="button">Submenu 2</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 2</a></div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const trigger1 = fixtureEl.querySelector('#trigger-1')
+        const trigger2 = fixtureEl.querySelector('#trigger-2')
+        const submenu1 = fixtureEl.querySelector('#submenu-1 > .menu')
+        const submenu2 = fixtureEl.querySelector('#submenu-2 > .menu')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          trigger1.click()
+          expect(submenu1).toHaveClass('show')
+
+          trigger1.focus()
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          trigger1.dispatchEvent(arrowDown)
+
+          expect(document.activeElement).toEqual(trigger2)
+          expect(submenu1).not.toHaveClass('show')
+          // Arrowing onto a trigger moves focus only, it does not open the submenu
+          expect(submenu2).not.toHaveClass('show')
+          expect(menu._openSubmenus.size).toEqual(0)
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should keep an open submenu when focus stays on its own trigger', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <a id="top-item" class="menu-item" href="#">Top</a>',
+          '    <div class="submenu" id="submenu-1">',
+          '      <button id="trigger-1" class="menu-item" type="button">Submenu 1</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 1</a></div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const topItem = fixtureEl.querySelector('#top-item')
+        const trigger1 = fixtureEl.querySelector('#trigger-1')
+        const submenu1 = fixtureEl.querySelector('#submenu-1 > .menu')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          trigger1.click()
+          expect(submenu1).toHaveClass('show')
+
+          topItem.focus()
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          topItem.dispatchEvent(arrowDown)
+
+          expect(document.activeElement).toEqual(trigger1)
+          expect(submenu1).toHaveClass('show')
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+
+    it('should resolve the owning menu when the menu is moved to a container', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button id="other-toggle" class="btn" data-bs-toggle="menu">Other menu</button>',
+          '  <div class="menu">',
+          '    <a class="menu-item" href="#">Other item</a>',
+          '  </div>',
+          '</div>',
+          '<div>',
+          '  <button id="contained-toggle" class="btn" data-bs-toggle="menu" data-bs-container="body">Contained menu</button>',
+          '  <div id="contained-menu" class="menu">',
+          '    <a id="contained-1" class="menu-item" href="#">Contained 1</a>',
+          '    <a id="contained-2" class="menu-item" href="#">Contained 2</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const otherToggle = fixtureEl.querySelector('#other-toggle')
+        const containedToggle = fixtureEl.querySelector('#contained-toggle')
+        const containedMenu = fixtureEl.querySelector('#contained-menu')
+        const contained1 = fixtureEl.querySelector('#contained-1')
+        const contained2 = fixtureEl.querySelector('#contained-2')
+        const menu = new Menu(containedToggle)
+
+        containedToggle.addEventListener('shown.bs.menu', () => {
+          expect(containedMenu.parentNode).toEqual(document.body)
+
+          contained1.focus()
+          const arrowDown = createEvent('keydown', { bubbles: true })
+          arrowDown.key = 'ArrowDown'
+          contained1.dispatchEvent(arrowDown)
+
+          expect(document.activeElement).toEqual(contained2)
+          // The first toggle in the document must not be mistaken for the owner
+          expect(otherToggle.getAttribute('aria-expanded')).not.toEqual('true')
+
+          menu.hide()
+          resolve()
         })
 
         menu.show()

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -2660,6 +2660,123 @@ describe('Menu', () => {
     })
   })
 
+  describe('submenu trigger markup', () => {
+    it('should mark every submenu trigger as a popup on init, at any depth', () => {
+      fixtureEl.innerHTML = [
+        '<div>',
+        '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+        '  <div class="menu">',
+        '    <a id="plain" class="menu-item" href="#">Plain</a>',
+        '    <div class="submenu">',
+        '      <button id="level-1" class="menu-item" type="button">Level 1</button>',
+        '      <div class="menu">',
+        '        <div class="submenu">',
+        '          <button id="level-2" class="menu-item" type="button">Level 2</button>',
+        '          <div class="menu"><a class="menu-item" href="#">Deep</a></div>',
+        '        </div>',
+        '      </div>',
+        '    </div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+      const plain = fixtureEl.querySelector('#plain')
+      const level1 = fixtureEl.querySelector('#level-1')
+      const level2 = fixtureEl.querySelector('#level-2')
+
+      // eslint-disable-next-line no-new
+      new Menu(btnMenu)
+
+      for (const trigger of [level1, level2]) {
+        expect(trigger.getAttribute('aria-haspopup')).toEqual('true')
+        expect(trigger.getAttribute('aria-expanded')).toEqual('false')
+      }
+
+      expect(plain.hasAttribute('aria-haspopup')).toBeFalse()
+      expect(plain.hasAttribute('aria-expanded')).toBeFalse()
+    })
+
+    it('should not mark a submenu wrapper that holds no nested menu', () => {
+      fixtureEl.innerHTML = [
+        '<div>',
+        '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+        '  <div class="menu">',
+        '    <div class="submenu">',
+        '      <button id="empty-trigger" class="menu-item" type="button">No submenu</button>',
+        '    </div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+      const emptyTrigger = fixtureEl.querySelector('#empty-trigger')
+
+      // eslint-disable-next-line no-new
+      new Menu(btnMenu)
+
+      expect(emptyTrigger.hasAttribute('aria-haspopup')).toBeFalse()
+      expect(emptyTrigger.hasAttribute('aria-expanded')).toBeFalse()
+    })
+
+    it('should keep an author supplied aria-expanded on a submenu trigger', () => {
+      fixtureEl.innerHTML = [
+        '<div>',
+        '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+        '  <div class="menu">',
+        '    <div class="submenu">',
+        '      <button id="trigger" class="menu-item" type="button" aria-expanded="true">Sub</button>',
+        '      <div class="menu"><a class="menu-item" href="#">Action</a></div>',
+        '    </div>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+      const trigger = fixtureEl.querySelector('#trigger')
+
+      // eslint-disable-next-line no-new
+      new Menu(btnMenu)
+
+      expect(trigger.getAttribute('aria-haspopup')).toEqual('true')
+      expect(trigger.getAttribute('aria-expanded')).toEqual('true')
+    })
+
+    it('should flip aria-expanded on the trigger as its submenu opens and closes', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu">',
+          '      <button id="trigger" class="menu-item" type="button">Sub</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action</a></div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const trigger = fixtureEl.querySelector('#trigger')
+        const menu = new Menu(btnMenu)
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          expect(trigger.getAttribute('aria-expanded')).toEqual('false')
+
+          trigger.click()
+          expect(trigger.getAttribute('aria-expanded')).toEqual('true')
+
+          trigger.click()
+          expect(trigger.getAttribute('aria-expanded')).toEqual('false')
+          expect(trigger.getAttribute('aria-haspopup')).toEqual('true')
+          resolve()
+        })
+
+        menu.show()
+      })
+    })
+  })
+
   describe('submenu', () => {
     // `_openSubmenu()` adds a `mouseenter` listener and `_closeSubmenu()` drops it again.
     // A failed removal used to leave one live listener behind per open and close cycle.

--- a/site/src/content/docs/components/menu.mdx
+++ b/site/src/content/docs/components/menu.mdx
@@ -536,6 +536,8 @@ The [<abbr title="Web Accessibility Initiative">WAI</abbr> <abbr title="Accessib
 
 Bootstrap’s menus, on the other hand, are designed to be generic and applicable to a variety of situations and markup structures. For instance, it is possible to create menus that contain additional inputs and form controls, such as search fields or login forms. For this reason, Bootstrap does not expect (nor automatically add) any of the `role` and `aria-` attributes required for true <abbr title="Accessible Rich Internet Applications">ARIA</abbr> menus. Authors will have to include these more specific attributes themselves.
 
+Submenu triggers are an exception. Bootstrap adds `aria-haspopup="true"` to each `.submenu > .menu-item` that wraps a nested `.menu`, and keeps `aria-expanded` on it in sync as the submenu opens and closes. Set `aria-expanded` yourself only if a submenu must start open.
+
 ### Keyboard navigation
 
 Menus include built-in keyboard support for navigating menu items.


### PR DESCRIPTION
- Arrow keys collected only the direct `.menu-item` children of `.menu`, so they skipped every submenu trigger, which sits at `.menu > .submenu > .menu-item`. A menu built entirely from submenus had no reachable items at all.
- Keys pressed inside an open submenu panel did nothing. The keydown handler is delegated on both the toggle and `.menu`, and delegation stops at the innermost match, so the handler ran on the nested `.menu`, where the toggle is not a sibling. The handler bailed out before any branch, which killed the arrows, Home, End, ArrowLeft and Escape. Escape failing left a keyboard user unable to dismiss the menu.
- The same lookup picked the first toggle in the document when a menu used `container`, so an arrow key could open an unrelated menu. The owning menu now resolves from the open instances first, and only then falls back to the sibling and wrapper lookups.
- Moving focus along a level now closes the submenus focus left behind, matching what hover and click already do.
- Submenu triggers get `aria-haspopup="true"` and a starting `aria-expanded="false"` when the instance is created, at any depth. An author-supplied `aria-expanded` is left alone, for a submenu that must start open. Documented in the menu accessibility section, which previously said Bootstrap adds no `aria-` attributes for you.
- Enter, Space and the RTL-aware enter arrow each opened a submenu through their own copy of the same sixteen lines. One guard now covers all three.
- Two existing specs claimed to cover the submenu ArrowLeft and Escape paths but called the methods directly instead of dispatching keys, and a third asserted nothing. That is why the regression stayed hidden. All three now dispatch real events, and new specs cover the arrows, Home, End, ArrowLeft and Escape inside open submenus, a third nesting level, and the `container` case.
- Raised the two minified JS budgets by a quarter kilobyte. This work adds about 190 bytes to each, which left both with roughly a hundred bytes of room.

Supersedes #42699