### PR TITLE
Sanitizer: block data:/vbscript: URLs (XSS hardening)

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "43.5 kB"
+      "maxSize": "43.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "28.5 kB"
+      "maxSize": "28.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",
@@ -50,7 +50,7 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "29.25 kB"
+      "maxSize": "29.0 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "43.0 kB"
+      "maxSize": "43.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "28.0 kB"
+      "maxSize": "28.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",
@@ -50,11 +50,11 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "28.75 kB"
+      "maxSize": "29.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16.25 kB"
+      "maxSize": "16.5 kB"
     }
   ],
   "ci": {

--- a/js/src/util/sanitizer.js
+++ b/js/src/util/sanitizer.js
@@ -63,14 +63,22 @@ const uriAttributes = new Set([
  *
  * Shout-out to Angular https://github.com/angular/angular/blob/15.2.8/packages/core/src/sanitization/url_sanitizer.ts#L38
  */
-const SAFE_URL_PATTERN = /^(?!javascript:)(?:[a-z0-9+.-]+:|[^&:/?#]*(?:[/?#]|$))/i
+const SAFE_URL_PATTERN = /^(?!(?:javascript|data|vbscript):)(?:[a-z0-9+.-]+:|[^&:/?#]*(?:[/?#]|$))/i
+
+/**
+ * A pattern that matches safe data URLs. Only matches image, video and audio
+ * types — notably NOT `data:text/html`, which is an XSS vector.
+ *
+ * Shout-out to Angular https://github.com/angular/angular/blob/15.2.8/packages/core/src/sanitization/url_sanitizer.ts#L49
+ */
+const DATA_URL_PATTERN = /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[\d+/a-z=]+$/i
 
 const allowedAttribute = (attribute, allowedAttributeList) => {
   const attributeName = attribute.nodeName.toLowerCase()
 
   if (allowedAttributeList.includes(attributeName)) {
     if (uriAttributes.has(attributeName)) {
-      return Boolean(SAFE_URL_PATTERN.test(attribute.nodeValue))
+      return Boolean(SAFE_URL_PATTERN.test(attribute.nodeValue) || DATA_URL_PATTERN.test(attribute.nodeValue))
     }
 
     return true

--- a/js/src/util/sanitizer.js
+++ b/js/src/util/sanitizer.js
@@ -71,7 +71,7 @@ const SAFE_URL_PATTERN = /^(?!(?:javascript|data|vbscript):)(?:[a-z0-9+.-]+:|[^&
  *
  * Shout-out to Angular https://github.com/angular/angular/blob/15.2.8/packages/core/src/sanitization/url_sanitizer.ts#L49
  */
-const DATA_URL_PATTERN = /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[\d+/a-z=]+$/i
+const DATA_URL_PATTERN = /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|mpeg|oga|ogg|opus));base64,[\d+/a-z=]+$/i
 
 const allowedAttribute = (attribute, allowedAttributeList) => {
   const attributeName = attribute.nodeName.toLowerCase()

--- a/js/src/util/sanitizer.js
+++ b/js/src/util/sanitizer.js
@@ -66,8 +66,9 @@ const uriAttributes = new Set([
 const SAFE_URL_PATTERN = /^(?!(?:javascript|data|vbscript):)(?:[a-z0-9+.-]+:|[^&:/?#]*(?:[/?#]|$))/i
 
 /**
- * A pattern that matches safe data URLs. Only matches image, video and audio
- * types — notably NOT `data:text/html`, which is an XSS vector.
+ * A pattern that matches safe data URLs. Only matches base64-encoded image,
+ * video and audio types — notably NOT `data:text/html`, and not non-base64
+ * media payloads (e.g. `data:image/png,...` without `;base64,`).
  *
  * Shout-out to Angular https://github.com/angular/angular/blob/15.2.8/packages/core/src/sanitization/url_sanitizer.ts#L49
  */

--- a/js/tests/unit/util/sanitizer.spec.js
+++ b/js/tests/unit/util/sanitizer.spec.js
@@ -67,7 +67,13 @@ describe('Sanitizer', () => {
         'jav\u0000ascript:alert();'
       ]
 
-      for (const url of invalidUrls) {
+      const dangerousDataUrls = [
+        'data:text/html,hello',
+        'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+        'vbscript:msgbox(1)'
+      ]
+
+      for (const url of [...invalidUrls, ...dangerousDataUrls]) {
         const template = [
           '<div>',
           `  <a href="${url}">Click me</a>`,

--- a/js/tests/unit/util/sanitizer.spec.js
+++ b/js/tests/unit/util/sanitizer.spec.js
@@ -31,6 +31,7 @@ describe('Sanitizer', () => {
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/', // Truncated.
         'data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
         'data:audio/opus;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
+        'data:audio/mpeg;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
         'unknown-scheme:abc'
       ]
 


### PR DESCRIPTION
### Description

The HTML sanitizer's `SAFE_URL_PATTERN` only rejected `javascript:`, so a `data:text/html,…` (or `vbscript:`) URL in an `href`/`src` passed the attribute allowList. Via tooltip/popover content (for example `data-bs-title` / `data-bs-content`) that is an XSS vector.

This is already fixed on `v6-dev` in #42549. The same gap is still present on the stable 5.3.x line shipped as 5.3.8.

### Changes

- `SAFE_URL_PATTERN` now also rejects `data:` and `vbscript:`
- Restore a `DATA_URL_PATTERN` that re-allows only safe base64 image/video/audio data URLs
- Extend the invalid-URL unit tests with `data:text/html` and `vbscript:` cases
- Bump JS bundlewatch budgets for the small size increase

### Related

- Backports #42549 to `main`
- Related to #42443