### PR TITLE
Docs: add file upload example

### DIFF
--- a/site/src/assets/examples/file-upload/index.html
+++ b/site/src/assets/examples/file-upload/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en" data-bs-theme="auto">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>File Upload Example · Bootstrap</title>
+
+    <!-- 1. Bootstrap Core CSS -->
+    <link href="/docs/5.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- 2. Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+    <!-- 3. Helper styles for dashed borders and layout height -->
+    <style>
+      .border-dashed {
+        border-style: dashed !important;
+      }
+      .cursor-pointer {
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Center the component vertically and horizontally in the viewport -->
+    <main class="d-flex justify-content-center align-items-center min-vh-100 bg-body-tertiary p-3">
+      
+      <div class="card w-100 p-5 text-center border-2 border-dashed border-secondary rounded-4 bg-body shadow-sm" style="max-width: 600px;">
+        <label for="fileInput" class="form-label mb-0 cursor-pointer d-flex flex-column align-items-center justify-content-center py-4">
+          <i class="bi bi-cloud-upload fs-1 text-secondary mb-2"></i>
+          <span class="fw-semibold text-body-emphasis fs-5">Drag & drop files here or click to browse</span>
+          <span class="text-body-secondary small mt-1">Supports PNG, JPG, PDF up to 10MB</span>
+        </label>
+        <input class="form-control d-none" type="file" id="fileInput" name="fileInput">
+      </div>
+
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Description

Adds a new framework-agnostic **File Upload** drag-and-drop zone example under `site/src/assets/examples/file-upload/index.html`. 

It includes:
- Pure HTML & Bootstrap 5 utility classes (`bg-body-tertiary`, `border-dashed`, `border-secondary`).
- Bootstrap Icons integration for file upload UI.
- Accessible `<label>` and hidden `<input type="file">` layout.

### Motivation & Context

File upload dropzones are a very common UI requirement in modern web applications. Adding an official framework-agnostic example gives Bootstrap developers a clean reference implementation using core utility classes without needing external plugins or frameworks.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- Netlify deploy preview will generate automatically once this PR is created.

### Related issues

N/A