### PR TITLE
Move deploy previews from Netlify to Vercel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@
 
 <!-- Please add direct links where your modifications can be seen in the documentation -->
 
-- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>
+- <https://bootstrap-{your_pr_number}--twbs.vercel.app/>
 
 ### Related issues
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@
 *.sublime-workspace
 nbproject
 Thumbs.db
-# Local Netlify folder
-.netlify
+# Local Vercel folder
+.vercel
 
 # Komodo
 .komodotools

--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ See [the Releases section of our GitHub project](https://github.com/twbs/bootstr
 
 ## Thanks
 
-<a href="https://www.netlify.com/">
-  <img src="https://www.netlify.com/v3/img/components/full-logo-light.svg" alt="Netlify" width="147" height="40">
+<a href="https://vercel.com/">
+  <img src="https://vercel.com/logotype/dark.svg" alt="Vercel" width="147" height="40">
 </a>
 
-Thanks to [Netlify](https://www.netlify.com/) for providing us with Deploy Previews!
+Thanks to [Vercel](https://vercel.com/) for providing us with Preview Deployments!
 
 ## Sponsors
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "release-zip-examples": "node build/zip-examples.mjs",
     "dist": "npm-run-all --aggregate-output --parallel css js",
     "test": "npm-run-all lint dist js-typecheck-dist js-test docs-build docs-lint",
-    "netlify": "npm-run-all dist release-sri astro-build",
+    "vercel": "npm-run-all dist release-sri astro-build",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix\"",
     "watch-css-docs": "nodemon --watch site/src/scss/ --ext scss --exec \"npm run css-lint\"",

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -31,9 +31,9 @@ const headingsRangeRegex = new RegExp(`^h[${getConfig().anchors.min}-${getConfig
 const site = isDev
   ? // In development mode, use the local dev server.
     `http://localhost:${port}`
-  : process.env.DEPLOY_PRIME_URL !== undefined
-    ? // If deploying on Netlify, use the `DEPLOY_PRIME_URL` environment variable.
-      process.env.DEPLOY_PRIME_URL
+  : process.env.VERCEL_ENV === 'preview'
+    ? // On Vercel preview deployments, use the `VERCEL_URL` environment variable.
+      `https://${process.env.VERCEL_URL}`
     : // Otherwise, use the `baseURL` value defined in the `config.yml` file.
       getConfig().baseURL
 

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -2,7 +2,9 @@
 /// <reference types="astro/client" />
 
 interface ImportMetaEnv {
-  readonly NETLIFY?: string
+  readonly VERCEL?: string
+  readonly VERCEL_ENV?: string
+  readonly VERCEL_URL?: string
 }
 
 interface ImportMeta {

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -2,9 +2,9 @@ import type { APIRoute } from 'astro'
 
 export const GET: APIRoute = function GET({ site }) {
   const isProduction = import.meta.env.PROD
-  const isNetlify = import.meta.env.NETLIFY === 'true'
+  const isPreviewDeploy = import.meta.env.VERCEL_ENV === 'preview'
 
-  const allowCrawling = !isNetlify && isProduction
+  const allowCrawling = !isPreviewDeploy && isProduction
 
   const robotsTxt = `# www.robotstxt.org${allowCrawling ? '\n# Allow crawling of all content' : ''}
 User-agent: *

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "installCommand": "npm ci",
+        "buildCommand": "npm run vercel",
+        "distDir": "_site"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Adds `vercel.json` and renames the `netlify` npm script to `vercel`
- Astro reads the preview host from `VERCEL_URL` when `VERCEL_ENV` is `preview`, replacing `DEPLOY_PRIME_URL`
- `robots.txt` blocks crawling on preview deployments, replacing the `NETLIFY` check
- Updates the PR template preview link, the `.gitignore` entry, and the README credit
