### PR TITLE
Docs: explain tables in rounded containers

### DIFF
--- a/site/src/content/docs/content/tables.mdx
+++ b/site/src/content/docs/content/tables.mdx
@@ -14,6 +14,53 @@ Using the most basic table markup, here’s how `.table`-based tables look in Bo
 
 <Table class="table" simplified={false} />
 
+### Tables in rounded containers
+
+Table cell backgrounds are opaque by default. When a table is placed inside a parent with rounded corners, the cell backgrounds can cover the parent’s border radius. Add the [`.overflow-auto` utility]([[docsref:/utilities/overflow]]) to the parent so its rounded corners clip the table. This also allows the table to scroll if it becomes wider than its container.
+
+<Example code={`<div class="border rounded-3 overflow-auto">
+  <table class="table table-striped mb-0">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">First</th>
+        <th scope="col">Last</th>
+        <th scope="col">Handle</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Mark</td>
+        <td>Otto</td>
+        <td>@mdo</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td>Jacob</td>
+        <td>Thornton</td>
+        <td>@fat</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>John</td>
+        <td>Doe</td>
+        <td>@social</td>
+      </tr>
+    </tbody>
+  </table>
+</div>`} />
+
+For a plain table, you can instead use `--bs-table-bg: transparent` to let the parent’s background show through. Accented tables, such as striped or hoverable tables, still need an overflow utility because their accent backgrounds can cover the rounded corners.
+
+```html
+<div class="border rounded-3 bg-body">
+  <table class="table mb-0" style="--bs-table-bg: transparent;">
+    <!-- ... -->
+  </table>
+</div>
+```
+
 ## Variants
 
 Use contextual classes to color tables, table rows or individual cells.


### PR DESCRIPTION
### Description

- Document why opaque table cell backgrounds can cover a rounded parent container.
- Add a copy-ready `.overflow-auto` example that clips accented table backgrounds while preserving horizontal scrolling.
- Document `--bs-table-bg: transparent` as an alternative for plain tables, including when it is not sufficient.

### Motivation & Context

Bootstrap 5.3's solid table cell backgrounds can obscure a wrapper's border radius. This documents both maintainer-endorsed workarounds from #41723 and clarifies the difference between plain and accented tables.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes _(not applicable: documentation-only change)_
- [ ] All new and existing tests passed _(809 JS assertions passed, but the local Chrome 151 Karma runner reported an unrelated full-page reload after completion; all documentation validations passed)_

#### Live previews

- <https://deploy-preview-42823--twbs-bootstrap.netlify.app/docs/5.3/content/tables/#tables-in-rounded-containers>

### Related issues

- Addresses #41723.

### Validation

- `npm run lint`
- `npm run dist`
- `npm run docs-build`
- `npm run docs-vnu`
- Prettier and CSpell checks for `site/src/content/docs/content/tables.mdx`
- Local rendered-page review in Chrome
- `npm run js-test`: 809/809 assertions passed; the local Chrome 151 Karma runner then reported a full-page reload environment error

Disclosure: Codex assisted with preparation; the source behavior, final diff, and rendered output were cross-checked locally.


#### Latest-head refresh (August 27, 2026)

Rebased cleanly onto Bootstrap main at `ae7d4c531`; the documentation target had no intervening changes. Revalidated exact head `be2eacec7` with:

- `npm run lint` (0 errors; 18 existing TODO warnings)
- `npm run docs-build` (176 pages; no broken links)
- Targeted Prettier and CSpell checks
- `git diff --check`
