### PR TITLE
Re-mint CSS vars for `.theme-contrast`

### DIFF
--- a/scss/helpers/_theme-colors.scss
+++ b/scss/helpers/_theme-colors.scss
@@ -3,4 +3,12 @@
 // Generate theme modifier classes (e.g., .theme-primary, .theme-accent, etc.)
 @layer helpers {
   @include generate-theme-classes();
+
+  // Remint fg tokens so reboot links stay legible on --theme-bg.
+  // Keep this out of utilities `variables` — that registers `@property { inherits: false }`.
+  // Do not put --theme-contrast first in reboot’s link stack: .theme-* always defines it.
+  .theme-contrast {
+    --theme-fg: var(--theme-contrast);
+    --theme-fg-emphasis: var(--theme-contrast);
+  }
 }

--- a/scss/helpers/_theme-colors.scss
+++ b/scss/helpers/_theme-colors.scss
@@ -4,11 +4,15 @@
 @layer helpers {
   @include generate-theme-classes();
 
-  // Remint fg tokens so reboot links stay legible on --theme-bg.
+  // Remint fg tokens so reboot links match each surface’s intended text pairing.
   // Keep this out of utilities `variables` — that registers `@property { inherits: false }`.
   // Do not put --theme-contrast first in reboot’s link stack: .theme-* always defines it.
   .theme-contrast {
     --theme-fg: var(--theme-contrast);
     --theme-fg-emphasis: var(--theme-contrast);
+  }
+
+  .theme-muted {
+    --theme-fg: var(--theme-fg-emphasis);
   }
 }

--- a/site/src/content/docs/utilities/theme.mdx
+++ b/site/src/content/docs/utilities/theme.mdx
@@ -35,6 +35,10 @@ And with borders:
 
 <Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-subtle theme-border">.theme-${themeColor.name} .theme-subtle .theme-border</div>`)} />
 
+Nested links inherit the subtle foreground so they stay legible on the subtle background:
+
+<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-3 theme-${themeColor.name} theme-subtle">Theme ${themeColor.title} with a <a class="underline-50 hover:underline-100" href="#">nested link</a> inside.</div>`)} />
+
 ### Muted
 
 Muted pairs the `bg-muted` theme token with the `text-emphasis` text color for a lower-contrast, more muted appearance. Like subtle, this combination will automatically adjust to the current color mode.
@@ -45,14 +49,18 @@ And with borders:
 
 <Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-muted theme-border">.theme-${themeColor.name} .theme-muted .theme-border</div>`)} />
 
+Nested links inherit the muted foreground so they stay legible on the muted background:
+
+<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-3 theme-${themeColor.name} theme-muted">Theme ${themeColor.title} with a <a class="underline-50 hover:underline-100" href="#">nested link</a> inside.</div>`)} />
+
 ## Comparison
 
 Here’s a side-by-side comparison of all three styles for each theme color, including nested links:
 
 <Example code={getData('theme-colors').map((themeColor) => `<div class="d-flex gap-2 mb-2">
-    <div class="theme-${themeColor.name} theme-contrast p-3 flex-fill text-center rounded">${themeColor.title} with a <a href="#">link</a></div>
-    <div class="theme-${themeColor.name} theme-subtle p-3 flex-fill text-center rounded">${themeColor.title} with a <a href="#">link</a></div>
-    <div class="theme-${themeColor.name} theme-muted p-3 flex-fill text-center rounded">${themeColor.title} with a <a href="#">link</a></div>
+    <div class="theme-${themeColor.name} theme-contrast p-3 flex-fill text-center rounded">${themeColor.title} with a <a class="underline-50 hover:underline-100" href="#">link</a></div>
+    <div class="theme-${themeColor.name} theme-subtle p-3 flex-fill text-center rounded">${themeColor.title} with a <a class="underline-50 hover:underline-100" href="#">link</a></div>
+    <div class="theme-${themeColor.name} theme-muted p-3 flex-fill text-center rounded">${themeColor.title} with a <a class="underline-50 hover:underline-100" href="#">link</a></div>
   </div>`)} />
 
 ## With components
@@ -102,6 +110,7 @@ The theme style classes generate the following CSS:
 }
 
 .theme-muted {
+  --theme-fg: var(--theme-fg-emphasis);
   background-color: var(--theme-bg-muted);
   color: var(--theme-fg-emphasis);
 }

--- a/site/src/content/docs/utilities/theme.mdx
+++ b/site/src/content/docs/utilities/theme.mdx
@@ -21,6 +21,10 @@ Contrast pairs the `bg` theme token with the `contrast` text color for maximum r
 
 <Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-contrast">.theme-${themeColor.name} .theme-contrast</div>`)} />
 
+Nested links inherit the contrast foreground so they stay legible on the solid background:
+
+<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-3 theme-${themeColor.name} theme-contrast">Theme ${themeColor.title} with a <a href="#">nested link</a> inside.</div>`)} />
+
 ### Subtle
 
 Subtle pairs the `bg-subtle` theme token with the `text` text color for a lower-contrast, more subtle appearance. This combination will automatically adjust to the current color mode.
@@ -43,12 +47,12 @@ And with borders:
 
 ## Comparison
 
-Here’s a side-by-side comparison of all three styles for each theme color:
+Here’s a side-by-side comparison of all three styles for each theme color, including nested links:
 
 <Example code={getData('theme-colors').map((themeColor) => `<div class="d-flex gap-2 mb-2">
-    <div class="theme-${themeColor.name} theme-contrast p-3 flex-fill text-center rounded">${themeColor.title} contrast</div>
-    <div class="theme-${themeColor.name} theme-subtle p-3 flex-fill text-center rounded">${themeColor.title} subtle</div>
-    <div class="theme-${themeColor.name} theme-muted p-3 flex-fill text-center rounded">${themeColor.title} muted</div>
+    <div class="theme-${themeColor.name} theme-contrast p-3 flex-fill text-center rounded">${themeColor.title} with a <a href="#">link</a></div>
+    <div class="theme-${themeColor.name} theme-subtle p-3 flex-fill text-center rounded">${themeColor.title} with a <a href="#">link</a></div>
+    <div class="theme-${themeColor.name} theme-muted p-3 flex-fill text-center rounded">${themeColor.title} with a <a href="#">link</a></div>
   </div>`)} />
 
 ## With components
@@ -86,6 +90,8 @@ The theme style classes generate the following CSS:
 
 ```css
 .theme-contrast {
+  --theme-fg: var(--theme-contrast);
+  --theme-fg-emphasis: var(--theme-contrast);
   background-color: var(--theme-bg);
   color: var(--theme-contrast);
 }

--- a/site/src/content/docs/utilities/theme.mdx
+++ b/site/src/content/docs/utilities/theme.mdx
@@ -17,13 +17,13 @@ Take any of our theme color classes and add `.theme-contrast`, `.theme-subtle`, 
 
 ### Contrast
 
-Contrast pairs the `bg` theme token with the `contrast` text color for maximum readability. This is ideal for high-emphasis elements with solid backgrounds.
+Contrast pairs the `bg` theme token with the `contrast` text color for maximum readability with `.theme-contrast`. This is ideal for high-emphasis elements with solid backgrounds.
 
 <Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-contrast">.theme-${themeColor.name} .theme-contrast</div>`)} />
 
 Nested links inherit the contrast foreground so they stay legible on the solid background:
 
-<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-3 theme-${themeColor.name} theme-contrast">Theme ${themeColor.title} with a <a href="#">nested link</a> inside.</div>`)} />
+<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-3 theme-${themeColor.name} theme-contrast">Theme ${themeColor.title} with a <a class="underline-50 hover:underline-100" href="#">nested link</a> inside.</div>`)} />
 
 ### Subtle
 


### PR DESCRIPTION
Help links have obvious contrast when used with `.theme-contrast`.

<img width="1802" height="1034" alt="CleanShot 2026-08-11 at 10 28 59@2x" src="https://github.com/user-attachments/assets/9c9473c9-cb9e-46ef-b101-f9bb7a6af09d" />
