### PR TITLE
Document Invoker Commands for Dialog and Drawer

### DIFF
--- a/site/src/content/docs/components/dialog.mdx
+++ b/site/src/content/docs/components/dialog.mdx
@@ -45,6 +45,31 @@ Toggle a dialog by clicking the button below. The dialog uses the native `showMo
     </div>
   </dialog>`} />
 
+## Without JavaScript
+
+Supported browsers can open and close a dialog with the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)—no Bootstrap JavaScript required. Set `commandfor` to the dialog’s `id`, use `command="show-modal"` to open, and `command="close"` to dismiss.
+
+<Callout type="warning">
+The Invoker Commands API is not supported in all browsers. For guaranteed support, use the `data-bs-toggle` examples above when you need our plugin options, events, or animated close.
+</Callout>
+
+<Example code={`<button type="button" class="btn-solid theme-primary" commandfor="invokerDialog" command="show-modal">
+    Open dialog
+  </button>
+
+  <dialog class="dialog" id="invokerDialog">
+    <div class="dialog-header">
+      <h1 class="dialog-title">Invoker Commands</h1>
+      <button type="button" class="btn-close" commandfor="invokerDialog" command="close" aria-label="Close"></button>
+    </div>
+    <div class="dialog-body">
+      <p>This dialog opens with <code>command="show-modal"</code> and closes with <code>command="close"</code>. No Bootstrap JavaScript is involved.</p>
+    </div>
+    <div class="dialog-footer">
+      <button type="button" class="btn-solid theme-secondary" commandfor="invokerDialog" command="close">Close</button>
+    </div>
+  </dialog>`} />
+
 ## Dark dialog
 
 To make a dialog dark, add `data-bs-theme="dark"` to the `<dialog>` element.

--- a/site/src/content/docs/components/drawer.mdx
+++ b/site/src/content/docs/components/drawer.mdx
@@ -72,6 +72,28 @@ Use the buttons below to show and hide a drawer element via JavaScript. You can 
     </div>
   </dialog>`} />
 
+### Without JavaScript
+
+Supported browsers can open and close a drawer with the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)—no Bootstrap JavaScript required. Set `commandfor` to the drawer’s `id`, use `command="show-modal"` to open, and `command="close"` to dismiss.
+
+<Callout type="warning">
+The Invoker Commands API is not supported in all browsers. For guaranteed support, use the `data-bs-toggle` examples above when you need our plugin options, events, swipe to dismiss, or animated close.
+</Callout>
+
+<Example code={`<button type="button" class="btn-solid theme-primary" commandfor="invokerDrawer" command="show-modal">
+    Open drawer
+  </button>
+
+  <dialog class="drawer drawer-start" tabindex="-1" id="invokerDrawer" aria-labelledby="invokerDrawerLabel">
+    <div class="drawer-header">
+      <h5 class="drawer-title" id="invokerDrawerLabel">Invoker Commands</h5>
+      <button type="button" class="btn-close" commandfor="invokerDrawer" command="close" aria-label="Close"></button>
+    </div>
+    <div class="drawer-body">
+      <p>This drawer opens with <code>command="show-modal"</code> and closes with <code>command="close"</code>. No Bootstrap JavaScript is involved.</p>
+    </div>
+  </dialog>`} />
+
 ### Body scrolling
 
 Scrolling the `<body>` element is disabled when a drawer and its backdrop are visible. Use the `data-bs-scroll` attribute to enable `<body>` scrolling.
@@ -88,7 +110,7 @@ Scrolling the `<body>` element is disabled when a drawer and its backdrop are vi
     </div>
   </dialog>`} />
 
-### Body scrolling and backdrop
+### Body scrolling & backdrop
 
 You can also enable `<body>` scrolling with a visible backdrop.
 

--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -94,6 +94,7 @@ These features sit above our floors, so v6 cannot use them without a fallback. F
 | --- | --- |
 | Relative color syntax, `rgb(from …)` | Chrome 131, Firefox 133 |
 | View transitions | Firefox 144 |
+| Invoker Commands API (`command` / `commandfor`) | Chrome 135, Firefox 144, Safari 26.2 |
 | `@scope` | Firefox 146 |
 | Anchor positioning | Firefox 147, Safari 26 |
 | Style container queries | Firefox 151 |


### PR DESCRIPTION
- Add no-JS Invoker Commands demos to Dialog and Drawer docs
- Note the API under browsers & devices “Not available yet”

Closes #42568