### PR TITLE
Close plain navbar drawers on resize past expand

### DIFF
--- a/js/src/drawer.ts
+++ b/js/src/drawer.ts
@@ -177,7 +177,9 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
 })
 
 EventHandler.on(window, EVENT_RESIZE, () => {
-  for (const element of SelectorEngine.find('dialog[open][class*="\\:drawer"]')) {
+  // Match plain `.drawer` (navbar expand) and responsive `.{bp}:drawer`.
+  // Hide when CSS has dropped the panel out of fixed positioning.
+  for (const element of SelectorEngine.find('dialog[open][class*="drawer"]')) {
     if (getComputedStyle(element).position !== 'fixed') {
       Drawer.getOrCreateInstance(element).hide()
     }

--- a/js/tests/unit/drawer.spec.js
+++ b/js/tests/unit/drawer.spec.js
@@ -232,6 +232,28 @@ describe('Drawer', () => {
         drawer.show()
       })
     })
+
+    it('should call `hide` on resize for plain `.drawer` when position is not fixed', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<dialog class="drawer drawer-end"></dialog>'
+
+        const drawerEl = fixtureEl.querySelector('dialog')
+        const drawer = new Drawer(drawerEl)
+
+        const spy = spyOn(drawer, 'hide').and.callThrough()
+
+        drawerEl.addEventListener('shown.bs.drawer', () => {
+          drawerEl.style.position = 'static'
+
+          const resizeEvent = createEvent('resize')
+          window.dispatchEvent(resizeEvent)
+          expect(spy).toHaveBeenCalled()
+          resolve()
+        })
+
+        drawer.show()
+      })
+    })
   })
 
   describe('config', () => {


### PR DESCRIPTION
- Widen the Drawer resize hide selector from `.{bp}:drawer` to any open `class*="drawer"`, so plain `.drawer` navbar panels close when CSS drops them out of `position: fixed`
- Add a unit test for the plain `.drawer` resize path

Fixes #42098