### PR TITLE
Add `:focus-within` styles to `.form-control`

### DIFF
--- a/scss/forms/_form-adorn.scss
+++ b/scss/forms/_form-adorn.scss
@@ -31,12 +31,6 @@ $form-adorn-tokens: defaults(
       outline: 0;
     }
 
-    &:focus-within {
-      --focus-ring-offset: -1px;
-      border-color: var(--focus-ring-color);
-      @include focus-ring(true);
-    }
-
     // Ghost input fills remaining space
     > .form-ghost {
       flex: 1;

--- a/scss/forms/_form-adorn.scss
+++ b/scss/forms/_form-adorn.scss
@@ -1,5 +1,4 @@
 @use "../functions" as *;
-@use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 
 $form-adorn-tokens: () !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -75,7 +75,8 @@ $form-control-sizes: defaults(
     );
 
     // Customize the `:focus` state to imitate native WebKit styles.
-    &:focus-visible {
+    &:focus-visible,
+    &:focus-within {
       --focus-ring-offset: -1px;
       @include focus-ring(true);
     }


### PR DESCRIPTION
- Apply `.form-control` focus styles on `:focus-within` so wrapper controls (chips, adornments) show the ring when a child input is focused
- Drop the duplicate `:focus-within` rule from `.form-adorn` now that the base class covers it

Fixes #40827