### PR TITLE
Docs: prerender pages with Speculation Rules

### DIFF
--- a/site/src/components/head/Analytics.astro
+++ b/site/src/components/head/Analytics.astro
@@ -5,7 +5,9 @@ const fathomSite = getConfig().analytics.fathom_site
 ---
 
 {/* Load Fathom only after activation so prerendered pages do not inflate views. */}
-<script is:inline set:html={`
+<script
+  is:inline
+  set:html={`
 (() => {
   const loadFathom = () => {
     const script = document.createElement('script')
@@ -21,4 +23,5 @@ const fathomSite = getConfig().analytics.fathom_site
     loadFathom()
   }
 })()
-`} />
+`}
+/>

--- a/site/src/components/head/Analytics.astro
+++ b/site/src/components/head/Analytics.astro
@@ -1,6 +1,24 @@
 ---
 import { getConfig } from '@libs/config'
+
+const fathomSite = getConfig().analytics.fathom_site
 ---
 
-<script is:inline defer src="https://cdn.usefathom.com/script.js" data-site={getConfig().analytics.fathom_site}
-></script>
+{/* Load Fathom only after activation so prerendered pages do not inflate views. */}
+<script is:inline set:html={`
+(() => {
+  const loadFathom = () => {
+    const script = document.createElement('script')
+    script.src = 'https://cdn.usefathom.com/script.js'
+    script.defer = true
+    script.dataset.site = ${JSON.stringify(fathomSite)}
+    document.head.appendChild(script)
+  }
+
+  if (document.prerendering) {
+    document.addEventListener('prerenderingchange', loadFathom, { once: true })
+  } else {
+    loadFathom()
+  }
+})()
+`} />

--- a/site/src/components/head/Head.astro
+++ b/site/src/components/head/Head.astro
@@ -70,4 +70,17 @@ const ScssProd = import.meta.env.PROD ? await import('@components/head/ScssProd.
 
 <Favicons />
 <Social description={description} layout={layout} thumbnail={thumbnail} title={title} />
+{/* Chromium Speculation Rules: prerender likely next docs pages on hover/intent. */}
+<script is:inline type="speculationrules">
+  {
+    "prerender": [
+      {
+        "where": {
+          "href_matches": "/*"
+        },
+        "eagerness": "moderate"
+      }
+    ]
+  }
+</script>
 <Analytics />


### PR DESCRIPTION
- Add Chromium Speculation Rules (`moderate` eagerness) so likely next docs pages prerender on hover/intent
- Defer Fathom until prerender activation so unused prerenders do not inflate pageviews

Closes #41907