### PR TITLE
Open collapses and tabs from URL hash links

### DIFF
--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -9,6 +9,7 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import type { ComponentConfig } from './util/config.js'
+import { enableHashTarget } from './util/hash-target.js'
 import {
   getElement,
   getTransitionDurationFromElement,
@@ -242,6 +243,37 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 
   for (const element of SelectorEngine.getMultipleElementsFromSelector(this)) {
     Collapse.getOrCreateInstance(element).toggle()
+  }
+})
+
+/**
+ * Find a trigger that targets this collapse.
+ */
+const getCollapseTrigger = (collapseEl: HTMLElement): HTMLElement | null => {
+  for (const trigger of SelectorEngine.find(SELECTOR_DATA_TOGGLE)) {
+    if (SelectorEngine.getMultipleElementsFromSelector(trigger).includes(collapseEl)) {
+      return trigger
+    }
+  }
+
+  return null
+}
+
+/**
+ * Open opted-in collapses when the URL fragment matches their id.
+ * Put `data-bs-hash` on the collapsible target.
+ */
+enableHashTarget(`${EVENT_KEY}${DATA_API_KEY}`, {
+  matches: element => element.classList.contains(CLASS_NAME_COLLAPSE),
+  getAnchor: getCollapseTrigger,
+  open(element, done) {
+    if (element.classList.contains(CLASS_NAME_SHOW)) {
+      done()
+      return
+    }
+
+    EventHandler.one(element, EVENT_SHOWN, done)
+    Collapse.getOrCreateInstance(element).show()
   }
 })
 

--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -92,7 +92,8 @@ const nativeEvents = new Set([
   'error',
   'abort',
   'scroll',
-  'scrollend'
+  'scrollend',
+  'hashchange'
 ])
 
 /**

--- a/js/src/tab.ts
+++ b/js/src/tab.ts
@@ -8,6 +8,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler, { type BootstrapEvent } from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { enableHashTarget } from './util/hash-target.js'
 import {
   getNextActiveElement, getTransitionDurationFromElement, isDisabled, setAriaAttribute
 } from './util/index.js'
@@ -299,6 +300,52 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
   for (const element of SelectorEngine.find(SELECTOR_DATA_TOGGLE_ACTIVE)) {
     Tab.getOrCreateInstance(element)
+  }
+})
+
+/**
+ * Find the tab trigger that targets a pane.
+ */
+const getTabTriggerFromPane = (pane: HTMLElement): HTMLElement | null => {
+  const labelledBy = pane.getAttribute('aria-labelledby')
+  if (labelledBy) {
+    const byLabel = document.getElementById(labelledBy)
+    if (byLabel?.matches(SELECTOR_DATA_TOGGLE)) {
+      return byLabel
+    }
+  }
+
+  const { id } = pane
+  if (!id) {
+    return null
+  }
+
+  const escapedId = CSS.escape(id)
+  return SelectorEngine.findOne(
+    `${SELECTOR_DATA_TOGGLE}[data-bs-target="#${escapedId}"], ${SELECTOR_DATA_TOGGLE}[href="#${escapedId}"]`
+  )
+}
+
+/**
+ * Open opted-in tab panes when the URL fragment matches their id.
+ * Put `data-bs-hash` on the tab pane.
+ */
+enableHashTarget(`${EVENT_KEY}.data-api`, {
+  matches: element => Boolean(getTabTriggerFromPane(element)),
+  getAnchor: getTabTriggerFromPane,
+  open(element, done) {
+    const trigger = getTabTriggerFromPane(element)
+    if (!trigger) {
+      return
+    }
+
+    if (trigger.classList.contains(CLASS_NAME_ACTIVE)) {
+      done()
+      return
+    }
+
+    EventHandler.one(trigger, EVENT_SHOWN, done)
+    Tab.getOrCreateInstance(trigger).show()
   }
 })
 

--- a/js/src/util/hash-target.ts
+++ b/js/src/util/hash-target.ts
@@ -1,0 +1,99 @@
+/**
+ * --------------------------------------------------------------------------
+ * Bootstrap util/hash-target.ts
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+import EventHandler from '../dom/event-handler.js'
+
+/**
+ * Constants
+ */
+
+const ATTR_HASH = 'data-bs-hash'
+
+type HashTargetHandler = {
+  /** Return true when this component should open the hashed element. */
+  matches: (element: HTMLElement) => boolean
+  /**
+   * Optional visible anchor to scroll before opening (usually the trigger).
+   * Closed collapses and inactive tab panes use `display: none`, so they cannot
+   * be scrolled to until after they open.
+   */
+  getAnchor?: (element: HTMLElement) => HTMLElement | null
+  /**
+   * Open the target. Call `done` after the open animation finishes,
+   * or immediately when the target is already open.
+   */
+  open: (element: HTMLElement, done: () => void) => void
+}
+
+/**
+ * Decode a URL fragment id, tolerating malformed escapes (returns it as-is).
+ */
+const decodeFragment = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Resolve the element named by `location.hash` when it opts in with `data-bs-hash`.
+ */
+const getHashTarget = (): HTMLElement | null => {
+  const { hash } = window.location
+  if (!hash || hash === '#') {
+    return null
+  }
+
+  const id = decodeFragment(hash.slice(1))
+  if (!id) {
+    return null
+  }
+
+  const element = document.getElementById(id)
+  if (!element?.hasAttribute(ATTR_HASH)) {
+    return null
+  }
+
+  return element
+}
+
+/**
+ * Open an opted-in hash target on `load` and `hashchange`.
+ * Put `data-bs-hash` on the collapse or tab pane that the URL fragment names.
+ *
+ * Scrolls a visible anchor first when one exists, then opens the target, then
+ * scrolls the target into view after it is shown.
+ */
+const enableHashTarget = (namespace: string, handler: HashTargetHandler): void => {
+  const onHash = (): void => {
+    const element = getHashTarget()
+    if (!element || !handler.matches(element)) {
+      return
+    }
+
+    const anchor = handler.getAnchor?.(element)
+    if (anchor) {
+      anchor.scrollIntoView()
+    }
+
+    handler.open(element, () => {
+      element.scrollIntoView()
+    })
+  }
+
+  EventHandler.on(window, `load${namespace}`, onHash)
+  EventHandler.on(window, `hashchange${namespace}`, onHash)
+}
+
+export {
+  ATTR_HASH,
+  decodeFragment,
+  enableHashTarget,
+  getHashTarget
+}
+export type { HashTargetHandler }

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -1,6 +1,16 @@
 import Collapse from '../../src/collapse.js'
 import EventHandler from '../../src/dom/event-handler.js'
-import { clearFixture, getFixture } from '../helpers/fixture.js'
+import { clearFixture, createEvent, getFixture } from '../helpers/fixture.js'
+
+const setHash = hash => {
+  const url = new URL(window.location.href)
+  url.hash = hash
+  window.history.replaceState(null, '', url)
+}
+
+const clearHash = () => {
+  setHash('')
+}
 
 describe('Collapse', () => {
   let fixtureEl
@@ -11,6 +21,7 @@ describe('Collapse', () => {
 
   afterEach(() => {
     clearFixture()
+    clearHash()
   })
 
   describe('VERSION', () => {
@@ -953,6 +964,79 @@ describe('Collapse', () => {
       expect(collapse2).toEqual(collapse)
 
       expect(collapse2._config.parent).toEqual(fixtureEl)
+    })
+  })
+
+  describe('hash target', () => {
+    it('should scroll the trigger, show the collapse, then scroll the target on load', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<a id="collapseHashTrigger" href="#collapseHash" data-bs-toggle="collapse">Toggle</a>',
+          '<div id="collapseHash" class="collapse" data-bs-hash></div>'
+        ].join('')
+
+        const triggerEl = fixtureEl.querySelector('#collapseHashTrigger')
+        const collapseEl = fixtureEl.querySelector('#collapseHash')
+        const triggerScrollSpy = spyOn(triggerEl, 'scrollIntoView')
+
+        spyOn(collapseEl, 'scrollIntoView').and.callFake(() => {
+          expect(triggerScrollSpy).toHaveBeenCalled()
+          expect(collapseEl).toHaveClass('show')
+          resolve()
+        })
+
+        setHash('collapseHash')
+        window.dispatchEvent(createEvent('load'))
+      })
+    })
+
+    it('should scroll the trigger, show the collapse, then scroll the target on hashchange', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<a id="collapseHashChangeTrigger" href="#collapseHashChange" data-bs-toggle="collapse">Toggle</a>',
+          '<div id="collapseHashChange" class="collapse" data-bs-hash></div>'
+        ].join('')
+
+        const triggerEl = fixtureEl.querySelector('#collapseHashChangeTrigger')
+        const collapseEl = fixtureEl.querySelector('#collapseHashChange')
+        const triggerScrollSpy = spyOn(triggerEl, 'scrollIntoView')
+
+        spyOn(collapseEl, 'scrollIntoView').and.callFake(() => {
+          expect(triggerScrollSpy).toHaveBeenCalled()
+          expect(collapseEl).toHaveClass('show')
+          resolve()
+        })
+
+        setHash('collapseHashChange')
+        window.dispatchEvent(createEvent('hashchange'))
+      })
+    })
+
+    it('should scroll an already-open hash target into view', () => {
+      fixtureEl.innerHTML = '<div id="collapseHashOpen" class="collapse show" data-bs-hash></div>'
+
+      const collapseEl = fixtureEl.querySelector('#collapseHashOpen')
+      const scrollSpy = spyOn(collapseEl, 'scrollIntoView')
+      const showSpy = spyOn(Collapse.prototype, 'show').and.callThrough()
+
+      setHash('collapseHashOpen')
+      window.dispatchEvent(createEvent('load'))
+
+      expect(showSpy).not.toHaveBeenCalled()
+      expect(scrollSpy).toHaveBeenCalled()
+    })
+
+    it('should ignore hash targets without data-bs-hash', () => {
+      fixtureEl.innerHTML = '<div id="collapseNoHash" class="collapse"></div>'
+
+      const collapseEl = fixtureEl.querySelector('#collapseNoHash')
+      const showSpy = spyOn(Collapse.prototype, 'show').and.callThrough()
+
+      setHash('collapseNoHash')
+      window.dispatchEvent(createEvent('load'))
+
+      expect(collapseEl).not.toHaveClass('show')
+      expect(showSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -3,6 +3,16 @@ import {
   clearFixture, createEvent, getFixture
 } from '../helpers/fixture.js'
 
+const setHash = hash => {
+  const url = new URL(window.location.href)
+  url.hash = hash
+  window.history.replaceState(null, '', url)
+}
+
+const clearHash = () => {
+  setHash('')
+}
+
 describe('Tab', () => {
   let fixtureEl
 
@@ -12,6 +22,7 @@ describe('Tab', () => {
 
   afterEach(() => {
     clearFixture()
+    clearHash()
   })
 
   describe('VERSION', () => {
@@ -1242,6 +1253,109 @@ describe('Tab', () => {
           resolve()
         }, 30)
       })
+    })
+  })
+
+  describe('hash target', () => {
+    it('should scroll the trigger, show the pane, then scroll the pane on load', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<ul class="nav nav-tabs" role="tablist">',
+          '  <li class="nav-item" role="presentation"><button type="button" data-bs-toggle="tab" data-bs-target="#homeHash" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
+          '  <li class="nav-item" role="presentation"><button type="button" id="triggerProfileHash" data-bs-toggle="tab" data-bs-target="#profileHash" class="nav-link" role="tab">Profile</button></li>',
+          '</ul>',
+          '<div class="tab-content">',
+          '  <div class="tab-pane active" id="homeHash" role="tabpanel"></div>',
+          '  <div class="tab-pane" id="profileHash" role="tabpanel" data-bs-hash></div>',
+          '</div>'
+        ].join('')
+
+        const trigger = fixtureEl.querySelector('#triggerProfileHash')
+        const pane = fixtureEl.querySelector('#profileHash')
+        const triggerScrollSpy = spyOn(trigger, 'scrollIntoView')
+
+        spyOn(pane, 'scrollIntoView').and.callFake(() => {
+          expect(triggerScrollSpy).toHaveBeenCalled()
+          expect(trigger).toHaveClass('active')
+          expect(pane).toHaveClass('active')
+          resolve()
+        })
+
+        setHash('profileHash')
+        window.dispatchEvent(createEvent('load'))
+      })
+    })
+
+    it('should scroll the trigger, show the pane, then scroll the pane on hashchange', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<ul class="nav nav-tabs" role="tablist">',
+          '  <li class="nav-item" role="presentation"><button type="button" data-bs-toggle="tab" data-bs-target="#homeHashChange" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
+          '  <li class="nav-item" role="presentation"><button type="button" id="triggerProfileHashChange" data-bs-toggle="tab" data-bs-target="#profileHashChange" class="nav-link" role="tab">Profile</button></li>',
+          '</ul>',
+          '<div class="tab-content">',
+          '  <div class="tab-pane active" id="homeHashChange" role="tabpanel"></div>',
+          '  <div class="tab-pane" id="profileHashChange" role="tabpanel" data-bs-hash></div>',
+          '</div>'
+        ].join('')
+
+        const trigger = fixtureEl.querySelector('#triggerProfileHashChange')
+        const pane = fixtureEl.querySelector('#profileHashChange')
+        const triggerScrollSpy = spyOn(trigger, 'scrollIntoView')
+
+        spyOn(pane, 'scrollIntoView').and.callFake(() => {
+          expect(triggerScrollSpy).toHaveBeenCalled()
+          expect(trigger).toHaveClass('active')
+          expect(pane).toHaveClass('active')
+          resolve()
+        })
+
+        setHash('profileHashChange')
+        window.dispatchEvent(createEvent('hashchange'))
+      })
+    })
+
+    it('should scroll an already-active hash tab pane into view', () => {
+      fixtureEl.innerHTML = [
+        '<ul class="nav nav-tabs" role="tablist">',
+        '  <li class="nav-item" role="presentation"><button type="button" data-bs-toggle="tab" data-bs-target="#homeHashOpen" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
+        '</ul>',
+        '<div class="tab-content">',
+        '  <div class="tab-pane active" id="homeHashOpen" role="tabpanel" data-bs-hash></div>',
+        '</div>'
+      ].join('')
+
+      const pane = fixtureEl.querySelector('#homeHashOpen')
+      const scrollSpy = spyOn(pane, 'scrollIntoView')
+      const showSpy = spyOn(Tab.prototype, 'show').and.callThrough()
+
+      setHash('homeHashOpen')
+      window.dispatchEvent(createEvent('load'))
+
+      expect(showSpy).not.toHaveBeenCalled()
+      expect(scrollSpy).toHaveBeenCalled()
+    })
+
+    it('should ignore tab panes without data-bs-hash', () => {
+      fixtureEl.innerHTML = [
+        '<ul class="nav nav-tabs" role="tablist">',
+        '  <li class="nav-item" role="presentation"><button type="button" data-bs-toggle="tab" data-bs-target="#homeNoHash" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
+        '  <li class="nav-item" role="presentation"><button type="button" id="triggerProfileNoHash" data-bs-toggle="tab" data-bs-target="#profileNoHash" class="nav-link" role="tab">Profile</button></li>',
+        '</ul>',
+        '<div class="tab-content">',
+        '  <div class="tab-pane active" id="homeNoHash" role="tabpanel"></div>',
+        '  <div class="tab-pane" id="profileNoHash" role="tabpanel"></div>',
+        '</div>'
+      ].join('')
+
+      const trigger = fixtureEl.querySelector('#triggerProfileNoHash')
+      const showSpy = spyOn(Tab.prototype, 'show').and.callThrough()
+
+      setHash('profileNoHash')
+      window.dispatchEvent(createEvent('load'))
+
+      expect(trigger).not.toHaveClass('active')
+      expect(showSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/site/src/content/docs/components/collapse.mdx
+++ b/site/src/content/docs/components/collapse.mdx
@@ -85,6 +85,22 @@ Conversely, multiple `<button>` or `<a>` elements can show and hide the same ele
     </div>
   </div>`} />
 
+## Hash links
+
+Add `data-bs-hash` to a collapsible target to open it when the URL fragment matches its `id`. Use a normal in-page link (without `data-bs-toggle`) to try it. You may need to use `scroll-margin-block-start` for some viewport offsetting if using a stickied or fixed navbar.
+
+<Example code={`<p class="d-inline-flex gap-1">
+    <a class="btn-outline theme-primary" href="#collapseHashExample">Open via hash link</a>
+    <button class="btn-solid theme-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapseHashExample" aria-expanded="false" aria-controls="collapseHashExample">
+      Toggle
+    </button>
+  </p>
+  <div class="collapse" id="collapseHashExample" data-bs-hash>
+    <div class="card card-body">
+      <p>Some placeholder content for a hash-linked collapse. Visiting <code>#collapseHashExample</code> opens this panel and scrolls it into view.</p>
+    </div>
+  </div>`} />
+
 ## Accessibility
 
 Be sure to add `aria-expanded` to the control element. This attribute explicitly conveys the current state of the collapsible element tied to the control to screen readers and similar assistive technologies. If the collapsible element is closed by default, the attribute on the control element should have a value of `aria-expanded="false"`. If you’ve set the collapsible element to be open by default using the `show` class, set `aria-expanded="true"` on the control instead. The plugin will automatically toggle this attribute on the control based on whether or not the collapsible element has been opened or closed (via JavaScript, or because the user triggered another control element also tied to the same collapsible element). If the control element’s HTML element is not a button (e.g., an `<a>` or `<div>`), the attribute `role="button"` should be added to the element.
@@ -128,6 +144,7 @@ To add accordion-like group management to a collapsible area, add the data attri
 | `data-bs-toggle="collapse"` | Initializes the collapse plugin on the trigger element. |
 | `data-bs-target` | CSS selector for the element(s) to expand and collapse. |
 | `data-bs-parent` | When set on the collapsible element, closes sibling collapses under the same parent (accordion behavior). |
+| `data-bs-hash` | When set on the collapsible target, opens that collapse when the URL fragment matches its `id` (on load and `hashchange`). See [Hash links](#hash-links). |
 </BsTable>
 
 ### Via JavaScript

--- a/site/src/content/docs/components/tab.mdx
+++ b/site/src/content/docs/components/tab.mdx
@@ -162,6 +162,38 @@ The tab plugin also works with [list groups]([[docsref:/components/list-group]])
   </div>
 </div>`} />
 
+## Hash links
+
+Add `data-bs-hash` to a tab pane to show it when the URL fragment matches its `id`. Use a normal in-page link to try it. You may need to use `scroll-margin-block-start` for some viewport offsetting if using a stickied or fixed navbar.
+
+<Example class="vstack gap-3" code={`<p class="d-inline-flex gap-2 mb-0">
+    <a href="#hash-home">#hash-home</a>
+    <a href="#hash-profile">#hash-profile</a>
+    <a href="#hash-contact">#hash-contact</a>
+  </p>
+  <ul class="nav nav-tabs" id="hashTab" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="hash-home-tab" data-bs-toggle="tab" data-bs-target="#hash-home" type="button" role="tab" aria-controls="hash-home" aria-selected="true">Home</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="hash-profile-tab" data-bs-toggle="tab" data-bs-target="#hash-profile" type="button" role="tab" aria-controls="hash-profile" aria-selected="false">Profile</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="hash-contact-tab" data-bs-toggle="tab" data-bs-target="#hash-contact" type="button" role="tab" aria-controls="hash-contact" aria-selected="false">Contact</button>
+    </li>
+  </ul>
+  <div class="tab-content" id="hashTabContent">
+    <div class="tab-pane show active" id="hash-home" role="tabpanel" aria-labelledby="hash-home-tab" tabindex="0" data-bs-hash>
+      <p>This is some placeholder content the <strong>Home tab’s</strong> associated content.</p>
+    </div>
+    <div class="tab-pane" id="hash-profile" role="tabpanel" aria-labelledby="hash-profile-tab" tabindex="0" data-bs-hash>
+      <p>This is some placeholder content the <strong>Profile tab’s</strong> associated content.</p>
+    </div>
+    <div class="tab-pane" id="hash-contact" role="tabpanel" aria-labelledby="hash-contact-tab" tabindex="0" data-bs-hash>
+      <p>This is some placeholder content the <strong>Contact tab’s</strong> associated content.</p>
+    </div>
+  </div>`} />
+
 ## Accessibility
 
 Dynamic tabbed interfaces, as described in the [ARIA Authoring Practices Guide tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/), require `role="tablist"`, `role="tab"`, `role="tabpanel"`, and additional `aria-` attributes in order to convey their structure, functionality, and current state to users of assistive technologies (such as screen readers). As a best practice, we recommend using `<button>` elements for the tabs, as these are controls that trigger a dynamic change, rather than links that navigate to a new page or location.
@@ -187,6 +219,7 @@ You can activate a tab navigation without writing any JavaScript by simply speci
 | --- | --- |
 | `data-bs-toggle="tab"` | Activates tab navigation on the trigger. |
 | `data-bs-target` | CSS selector for the tab pane to show (must pair with a corresponding `.tab-pane`). |
+| `data-bs-hash` | When set on the tab pane, shows that pane when the URL fragment matches its `id` (on load and `hashchange`). See [Hash links](#hash-links). |
 </BsTable>
 
 ```html

--- a/site/src/libs/js-dependencies.ts
+++ b/site/src/libs/js-dependencies.ts
@@ -24,6 +24,7 @@ const FILE_DESCRIPTIONS: Record<string, string> = {
   'util/component-functions': 'Shared component helpers',
   'util/config': 'Configuration base class',
   'util/floating-ui': 'Responsive placement utilities',
+  'util/hash-target': 'URL hash target helpers',
   'util/index': 'Core utility functions',
   'util/sanitizer': 'HTML content sanitizer',
   'util/swipe': 'Swipe gesture utilities',

--- a/site/src/scss/_scrolling.scss
+++ b/site/src/scss/_scrolling.scss
@@ -10,7 +10,8 @@
     h2,
     h3,
     h4,
-    [tabindex="0"] {
+    [tabindex="0"],
+    [data-bs-hash] {
       scroll-margin-block-start: var(--bd-navbar-offset);
       scroll-margin-block-end: 100px;
     }


### PR DESCRIPTION
- Add opt-in `data-bs-hash` on collapse and tab pane targets so `#fragment` links can open them
- On `load` and `hashchange`, scroll the trigger first, show the panel, then scroll the target into view
- Document with Hash links examples, and include `[data-bs-hash]` in docs scroll-margin rules

Fixes #34299