### PR TITLE
Make tooltips hover-able

### DIFF
--- a/js/src/tooltip.ts
+++ b/js/src/tooltip.ts
@@ -100,6 +100,10 @@ type TooltipConfig = {
   trigger: string
 }
 
+// Delegated tooltips are created on the fly with their `trigger` forced to
+// `manual`, so the real trigger is stored here for later reference.
+type TooltipInternalConfig = TooltipConfig & { _trigger: string }
+
 const Default: TooltipConfig = {
   allowList: DefaultAllowlist,
   animation: true,
@@ -157,6 +161,7 @@ class Tooltip extends BaseComponent {
   protected declare _activeTrigger: Record<string, boolean>
   protected declare _floatingCleanup: (() => void) | null
   protected declare _keydownHandler: ((event: KeyboardEvent) => void) | null
+  protected declare _tipEventOut: ((event: BootstrapEvent) => void) | null
   protected declare _templateFactory: TemplateFactory | null
   protected declare _newContent: Record<string, TemplateContentEntry> | null
   protected declare _mediaQueryListeners: BreakpointListener[]
@@ -179,6 +184,7 @@ class Tooltip extends BaseComponent {
     this._activeTrigger = {}
     this._floatingCleanup = null
     this._keydownHandler = null
+    this._tipEventOut = null
     this._templateFactory = null
     this._newContent = null
     this._mediaQueryListeners = []
@@ -282,6 +288,7 @@ class Tooltip extends BaseComponent {
     if (!this._element.ownerDocument.documentElement.contains(this.tip)) {
       container.append(tip)
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_INSERTED))
+      this._setTipListeners(tip)
     }
 
     await this._createFloating(tip)
@@ -641,12 +648,7 @@ class Tooltip extends BaseComponent {
           context.toggle()
         })
       } else if (trigger !== TRIGGER_MANUAL) {
-        const eventIn = trigger === TRIGGER_HOVER ?
-          this.constructor.eventName(EVENT_MOUSEENTER) :
-          this.constructor.eventName(EVENT_FOCUSIN)
-        const eventOut = trigger === TRIGGER_HOVER ?
-          this.constructor.eventName(EVENT_MOUSELEAVE) :
-          this.constructor.eventName(EVENT_FOCUSOUT)
+        const [eventIn, eventOut] = this._getTriggerEvents(trigger)
 
         EventHandler.on(this._element, eventIn, this._config.selector as string, event => {
           const context = this._initializeOnDelegatedTarget(event)
@@ -656,7 +658,7 @@ class Tooltip extends BaseComponent {
         EventHandler.on(this._element, eventOut, this._config.selector as string, event => {
           const context = this._initializeOnDelegatedTarget(event)
           context._activeTrigger[event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER] =
-            context._element.contains(event.relatedTarget)
+            context._isInside(event.relatedTarget)
 
           context._leave()
         })
@@ -670,6 +672,69 @@ class Tooltip extends BaseComponent {
     }
 
     EventHandler.on(this._element.closest(SELECTOR_MODAL), EVENT_MODAL_HIDE, this._hideModalHandler)
+  }
+
+  // Keep the tooltip open while the pointer or focus moves onto the tip
+  // itself, so users can reach interactive content inside it (WCAG 1.4.13).
+  // Hover/focus tips get matching leave listeners on the tip element.
+  protected _setTipListeners(tip: HTMLElement): void {
+    const trigger = this._getTrigger()
+
+    if (trigger === TRIGGER_MANUAL || trigger.includes(TRIGGER_CLICK)) {
+      return
+    }
+
+    this._tipEventOut = event => {
+      this._activeTrigger[event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER] = this._isInside(event.relatedTarget)
+      this._leave()
+    }
+
+    for (const name of trigger.split(' ')) {
+      if (name === TRIGGER_HOVER || name === TRIGGER_FOCUS) {
+        const [, eventOut] = this._getTriggerEvents(name)
+        EventHandler.on(tip, eventOut, this._tipEventOut)
+      }
+    }
+  }
+
+  protected _removeTipListeners(tip: HTMLElement): void {
+    if (!this._tipEventOut) {
+      return
+    }
+
+    const trigger = this._getTrigger()
+
+    for (const name of trigger.split(' ')) {
+      if (name === TRIGGER_HOVER || name === TRIGGER_FOCUS) {
+        const [, eventOut] = this._getTriggerEvents(name)
+        EventHandler.off(tip, eventOut, this._tipEventOut)
+      }
+    }
+
+    this._tipEventOut = null
+  }
+
+  protected _isInside(element: Node | null): boolean {
+    return this._element.contains(element) || Boolean(this.tip?.contains(element))
+  }
+
+  protected _getTrigger(): string {
+    return (this._config as TooltipInternalConfig)._trigger
+  }
+
+  protected _getTriggerEvents(trigger: string): [string, string] {
+    const events: Record<string, [string, string]> = {
+      [TRIGGER_HOVER]: [
+        this.constructor.eventName(EVENT_MOUSEENTER),
+        this.constructor.eventName(EVENT_MOUSELEAVE)
+      ],
+      [TRIGGER_FOCUS]: [
+        this.constructor.eventName(EVENT_FOCUSIN),
+        this.constructor.eventName(EVENT_FOCUSOUT)
+      ]
+    }
+
+    return events[trigger]
   }
 
   protected _setEscapeListener(): void {
@@ -798,6 +863,11 @@ class Tooltip extends BaseComponent {
   protected override _configAfterMerge(config: ComponentConfig): ComponentConfig {
     config.container = config.container === false ? document.body : getElement(config.container)
 
+    // Delegated tooltips are created on the fly with `trigger` set to `manual`,
+    // which makes the real trigger hard to check later. Preserve it here so the
+    // tip listeners know whether the tooltip is hover- or focus-driven.
+    config._trigger = config._trigger || config.trigger
+
     if (typeof config.delay === 'number') {
       config.delay = {
         show: config.delay,
@@ -844,6 +914,7 @@ class Tooltip extends BaseComponent {
     }
 
     if (this.tip) {
+      this._removeTipListeners(this.tip)
       this.tip.remove()
       this.tip = null
     }

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -861,6 +861,60 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should not hide a tooltip if the cursor moves from the trigger onto the tip', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">trigger</a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        const spy = spyOn(tooltip, 'hide').and.callThrough()
+
+        tooltipEl.addEventListener('mouseover', () => {
+          const moveMouseToTipEvent = createEvent('mouseout')
+          Object.defineProperty(moveMouseToTipEvent, 'relatedTarget', {
+            value: tooltip._getTipElement()
+          })
+
+          tooltipEl.dispatchEvent(moveMouseToTipEvent)
+        })
+
+        tooltipEl.addEventListener('mouseout', () => {
+          expect(spy).not.toHaveBeenCalled()
+          resolve()
+        })
+
+        tooltipEl.dispatchEvent(createEvent('mouseover'))
+      })
+    })
+
+    it('should hide a tooltip when the cursor leaves the tip element', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">trigger</a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        const spy = spyOn(tooltip, 'hide').and.callThrough()
+
+        tooltipEl.addEventListener('shown.bs.tooltip', () => {
+          const leaveTipEvent = createEvent('mouseout')
+          Object.defineProperty(leaveTipEvent, 'relatedTarget', {
+            value: document.body
+          })
+
+          tooltip._getTipElement().dispatchEvent(leaveTipEvent)
+        })
+
+        tooltipEl.addEventListener('hidden.bs.tooltip', () => {
+          expect(spy).toHaveBeenCalled()
+          resolve()
+        })
+
+        tooltipEl.dispatchEvent(createEvent('mouseover'))
+      })
+    })
+
     it('should properly maintain tooltip state if leave event occurs and enter event occurs during hide transition', () => {
       return new Promise(resolve => {
         // Style this tooltip to give it plenty of room for Floating UI to do what it wants

--- a/site/src/content/docs/components/tooltip.mdx
+++ b/site/src/content/docs/components/tooltip.mdx
@@ -133,6 +133,17 @@ With an SVG:
     </svg>
   </a>`} />
 
+### Interactive tooltips
+
+Move the pointer onto the tip to reach interactive content inside it, such as a link. The tooltip stays open while the pointer is over the trigger or the tip. It hides when the pointer leaves both, or when you press the <kbd>Escape</kbd> key. This helps satisfy the [WCAG 1.4.13 “Content on Hover or Focus”](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion.
+
+<Example class="tooltip-demo" addStackblitzJs code={`<button type="button" class="btn-solid theme-primary"
+          data-bs-toggle="tooltip"
+          data-bs-html="true"
+          data-bs-title="Read the <a href='https://getbootstrap.com/'>full docs</a> for more.">
+    Hover, then move onto the tip
+  </button>`} />
+
 ### Disabled elements
 
 Elements with the `disabled` attribute aren’t interactive, meaning users cannot focus, hover, or click them to trigger a tooltip (or popover). As a workaround, you’ll want to trigger the tooltip from a wrapper `<div>` or `<span>`, ideally made keyboard-focusable using `tabindex="0"`.
@@ -201,7 +212,7 @@ The required markup for a tooltip is only a `data` attribute and `title` on the 
 **Keep tooltips accessible to keyboard and assistive technology users** by only adding them to HTML elements that are traditionally keyboard-focusable and interactive (such as links or form controls). While other HTML elements can be made focusable by adding `tabindex="0"`, this can create annoying and confusing tab stops on non-interactive elements for keyboard users, and most assistive technologies currently do not announce tooltips in this situation. Additionally, do not rely solely on `hover` as the trigger for your tooltips as this will make them impossible to trigger for keyboard users.
 </Callout>
 
-A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, helping satisfy the [WCAG 1.4.13 “Content on Hover or Focus”](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion. As with dropdown menus, a tooltip shown inside a dialog is dismissed on its own: the first <kbd>Escape</kbd> closes the tooltip and a subsequent one closes the dialog.
+A shown tooltip can be dismissed by pressing the <kbd>Escape</kbd> key, helping satisfy the [WCAG 1.4.13 “Content on Hover or Focus”](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) success criterion. The tooltip also stays open while the pointer moves onto the tip, so users can reach interactive content inside it. As with dropdown menus, a tooltip shown inside a dialog is dismissed on its own: the first <kbd>Escape</kbd> closes the tooltip and a subsequent one closes the dialog.
 
 ```html
 <!-- HTML to write -->


### PR DESCRIPTION
- Keep a tooltip open while the pointer moves from the trigger onto the tip, so users can reach interactive content inside it (WCAG 1.4.13 "Content on Hover or Focus").
- Treat the tip as part of the trigger in `_isInside()`, and attach matching `mouseleave`/`focusout` listeners on the tip so leaving it hides the tooltip.
- Preserve the real trigger as an internal `_trigger` so delegated tooltips (forced to `manual`) still know they are hover/focus-driven; kept off the exported `TooltipConfig`.
- Add an "Interactive tooltips" docs example and a note in the accessibility section.
- Modernize the two original specs to the v6 Promise style.

The Escape-key dismiss half of #35151 already exists in v6, so this ports only the hover-able behavior.

Closes #28411
Supersedes #35151

Co-authored-by: Ryan Berliner <ryan.berliner@gmail.com>