### PR TITLE
Use defaults() for global config maps and $badge-variants

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -25,18 +25,22 @@ $badge-tokens: defaults(
 // scss-docs-end badge-tokens
 
 // scss-docs-start badge-variants
-$badge-variants: (
-  "subtle": (
-    "color": "fg",
-    "bg": "bg-subtle",
-    "border-color": "transparent"
+$badge-variants: () !default;
+$badge-variants: defaults(
+  (
+    "subtle": (
+      "color": "fg",
+      "bg": "bg-subtle",
+      "border-color": "transparent"
+    ),
+    "outline": (
+      "color": "fg",
+      "bg": "transparent",
+      "border-color": "border"
+    )
   ),
-  "outline": (
-    "color": "fg",
-    "bg": "transparent",
-    "border-color": "border"
-  )
-) !default;
+  $badge-variants
+);
 // scss-docs-end badge-variants
 
 // stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -60,23 +60,33 @@ $color-mix-space: lab !default;
 $tint-color: var(--white) !default;
 $shade-color: var(--black) !default;
 
-$color-tints: (
-  "025": 94%,
-  "050": 90%,
-  "100": 80%,
-  "200": 60%,
-  "300": 40%,
-  "400": 20%,
-) !default;
+$color-tints: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$color-tints: defaults(
+  (
+    "025": 94%,
+    "050": 90%,
+    "100": 80%,
+    "200": 60%,
+    "300": 40%,
+    "400": 20%,
+  ),
+  $color-tints
+);
 
-$color-shades: (
-  "600": 16%,
-  "700": 32%,
-  "800": 48%,
-  "900": 64%,
-  "950": 76%,
-  "975": 88%,
-) !default;
+$color-shades: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$color-shades: defaults(
+  (
+    "600": 16%,
+    "700": 32%,
+    "800": 48%,
+    "900": 64%,
+    "950": 76%,
+    "975": 88%,
+  ),
+  $color-shades
+);
 // scss-docs-end color-mix-options
 
 // scss-docs-start color-tokens

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -45,53 +45,73 @@ $min-contrast-ratio:         4.5 !default;
 
 // scss-docs-start spacer-variables-maps
 $spacer: 1rem !default;
-$spacers: (
-  0: 0,
-  1: $spacer * .25,
-  2: $spacer * .5,
-  3: $spacer * .75,
-  4: $spacer,
-  5: $spacer * 1.25,
-  6: $spacer * 1.5,
-  7: $spacer * 2,
-  8: $spacer * 2.5,
-  9: $spacer * 3,
-) !default;
+$spacers: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$spacers: defaults(
+  (
+    0: 0,
+    1: $spacer * .25,
+    2: $spacer * .5,
+    3: $spacer * .75,
+    4: $spacer,
+    5: $spacer * 1.25,
+    6: $spacer * 1.5,
+    7: $spacer * 2,
+    8: $spacer * 2.5,
+    9: $spacer * 3,
+  ),
+  $spacers
+);
 
-$negative-spacers: (
-  "-1": $spacer * -.25,
-  "-2": $spacer * -.5,
-) !default;
+$negative-spacers: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$negative-spacers: defaults(
+  (
+    "-1": $spacer * -.25,
+    "-2": $spacer * -.5,
+  ),
+  $negative-spacers
+);
 // scss-docs-end spacer-variables-maps
 
-$sizes: (
-  1: $spacer,
-  2: $spacer * 2,
-  3: $spacer * 3,
-  4: $spacer * 4,
-  5: $spacer * 5,
-  6: $spacer * 6,
-  7: $spacer * 7,
-  8: $spacer * 8,
-  9: $spacer * 9,
-  10: $spacer * 10,
-  11: $spacer * 11,
-  12: $spacer * 12,
-) !default;
+$sizes: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$sizes: defaults(
+  (
+    1: $spacer,
+    2: $spacer * 2,
+    3: $spacer * 3,
+    4: $spacer * 4,
+    5: $spacer * 5,
+    6: $spacer * 6,
+    7: $spacer * 7,
+    8: $spacer * 8,
+    9: $spacer * 9,
+    10: $spacer * 10,
+    11: $spacer * 11,
+    12: $spacer * 12,
+  ),
+  $sizes
+);
 
 $radius: .5rem !default;
-$radii: (
-  0: 0,
-  1: $radius * .25,
-  2: $radius * .375,
-  3: $radius * .5,
-  4: $radius * .75,
-  5: $radius,
-  6: $radius * 1.25,
-  7: $radius * 1.5,
-  8: $radius * 2,
-  9: $radius * 3,
-) !default;
+$radii: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$radii: defaults(
+  (
+    0: 0,
+    1: $radius * .25,
+    2: $radius * .375,
+    3: $radius * .5,
+    4: $radius * .75,
+    5: $radius,
+    6: $radius * 1.25,
+    7: $radius * 1.5,
+    8: $radius * 2,
+    9: $radius * 3,
+  ),
+  $radii
+);
 
 // Breakpoints
 //
@@ -128,13 +148,18 @@ $gutters: $spacers !default;
 // Define the maximum width of `.container` for different screen sizes.
 
 // scss-docs-start container-max-widths
-$container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1200px,
-  2xl: 1440px
-) !default;
+$container-max-widths: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$container-max-widths: defaults(
+  (
+    sm: 540px,
+    md: 720px,
+    lg: 960px,
+    xl: 1200px,
+    2xl: 1440px
+  ),
+  $container-max-widths
+);
 // scss-docs-end container-max-widths
 
 $container-padding-x: $grid-gutter-x !default;
@@ -163,11 +188,16 @@ $gradient: linear-gradient(180deg, color-mix(var(--white) 15%, transparent), col
 // Define the edge positioning anchors of the position utilities.
 
 // scss-docs-start position-map
-$position-values: (
-  0: 0,
-  50: 50%,
-  100: 100%
-) !default;
+$position-values: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$position-values: defaults(
+  (
+    0: 0,
+    50: 50%,
+    100: 100%
+  ),
+  $position-values
+);
 // scss-docs-end position-map
 
 
@@ -177,14 +207,19 @@ $position-values: (
 
 // scss-docs-start border-variables
 $border-width:                1px !default;
-$border-widths: (
-  keyline: .5px,
-  1: 1px,
-  2: 2px,
-  3: 3px,
-  4: 4px,
-  5: 5px
-) !default;
+$border-widths: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$border-widths: defaults(
+  (
+    keyline: .5px,
+    1: 1px,
+    2: 2px,
+    3: 3px,
+    4: 4px,
+    5: 5px
+  ),
+  $border-widths
+);
 $border-style:                solid !default;
 $border-color:                color-mix(in oklch, var(--gray-100), var(--gray-200)) !default;
 // scss-docs-end border-variables
@@ -225,25 +260,35 @@ $shadows: (
 // scss-docs-end box-shadow-variables
 
 // scss-docs-start aspect-ratios
-$aspect-ratios: (
-  "auto": auto,
-  "1x1": #{"1 / 1"},
-  "4x3": #{"4 / 3"},
-  "16x9": #{"16 / 9"},
-  "21x9": #{"21 / 9"}
-) !default;
+$aspect-ratios: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$aspect-ratios: defaults(
+  (
+    "auto": auto,
+    "1x1": #{"1 / 1"},
+    "4x3": #{"4 / 3"},
+    "16x9": #{"16 / 9"},
+    "21x9": #{"21 / 9"}
+  ),
+  $aspect-ratios
+);
 // scss-docs-end aspect-ratios
 
 // scss-docs-start font-weights
-$font-weights: (
-  lighter: lighter,
-  light: 300,
-  normal: 400,
-  medium: 500,
-  semibold: 600,
-  bold: 700,
-  bolder: bolder
-) !default;
+$font-weights: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$font-weights: defaults(
+  (
+    lighter: lighter,
+    light: 300,
+    normal: 400,
+    medium: 500,
+    semibold: 600,
+    bold: 700,
+    bolder: bolder
+  ),
+  $font-weights
+);
 // scss-docs-end font-weights
 
 // scss-docs-start font-sizes

--- a/scss/tests/jasmine.cjs
+++ b/scss/tests/jasmine.cjs
@@ -8,7 +8,7 @@ module.exports = {
   spec_dir: 'scss',
   // Make Jasmine look for `.test.scss` files
   // spec_files: ['**/*.{test,spec}.scss'],
-  spec_files: ['**/_utilities.test.scss', '**/utilities/_api.test.scss', '**/modules/_configuration.test.scss', '**/modules/_root-tokens.test.scss', '**/forms/_validation.test.scss', '**/mixins/_color-mode-*.test.scss'],
+  spec_files: ['**/_utilities.test.scss', '**/utilities/_api.test.scss', '**/modules/_configuration.test.scss', '**/modules/_config-maps.test.scss', '**/modules/_root-tokens.test.scss', '**/forms/_validation.test.scss', '**/mixins/_color-mode-*.test.scss'],
   // Compile them into JS scripts running `sass-true`
   requires: [path.join(__dirname, 'sass-true/register.cjs')],
   // Ensure we use `require` so that the require.extensions works

--- a/scss/tests/modules/_config-maps.test.scss
+++ b/scss/tests/modules/_config-maps.test.scss
@@ -1,0 +1,45 @@
+@use "sass:map";
+
+// Configure global config maps through the entrypoint. This checks that
+// `defaults()` merges overrides on top of the built-ins instead of replacing
+// the whole map.
+@use "../../bootstrap" as * with (
+  $spacers: (
+    "custom": 4rem,
+  ),
+  $badge-variants: (
+    "brand": (
+      "color": "contrast",
+      "bg": "bg",
+      "border-color": "transparent"
+    ),
+  )
+);
+
+$true-terminal-output: false;
+
+@include describe("Config map configuration") {
+  @include describe("@use bootstrap with config maps") {
+    @include it("should add a custom spacer and keep the built-ins") {
+      @include assert-true(
+        map.has-key($spacers, "custom"),
+        "The custom spacer should be configurable via @use ... with"
+      );
+      @include assert-true(
+        map.has-key($spacers, 3),
+        "Adding a spacer must not drop the built-in spacers"
+      );
+    }
+
+    @include it("should add a custom badge variant and keep the built-ins") {
+      @include assert-true(
+        map.has-key($badge-variants, "brand"),
+        "The custom badge variant should merge on top of the built-ins"
+      );
+      @include assert-true(
+        map.has-key($badge-variants, "subtle"),
+        "Adding a variant must not drop the built-in badge variants"
+      );
+    }
+  }
+}


### PR DESCRIPTION
Extends the `defaults()` pattern to the remaining plain `!default` map literals, so `@use ... with (...)` merges overrides on top of the built-ins and a `null` value removes a key — matching every other token, size, and variant map.

- Converts `$spacers`, `$negative-spacers`, `$sizes`, `$radii`, `$border-widths`, `$container-max-widths`, `$position-values`, `$aspect-ratios`, `$font-weights` (`scss/_config.scss`), `$color-tints`, `$color-shades` (`scss/_colors.scss`), and `$badge-variants` (`scss/_badge.scss`, now consistent with `$button-variants`).
- Adds a regression test that merges `$spacers` and `$badge-variants` through the entrypoint and asserts the built-ins survive.
- Default build output is byte-identical.

Left as-is on purpose: `$breakpoints` and `$zindex-levels` (order- and assertion-sensitive, and customization is discouraged), `$shadows` (structure-heavy and overridden at runtime via `--box-shadow*` / `--shadow-*`), and `$escaped-characters` / `$btn-variant-selectors` (lists, where the `defaults()` list branch would coerce them to `key: true` maps).

Follow-up to #42849.