### PR TITLE
Wrap TOC titles and fade the scroll edges

### DIFF
--- a/site/src/assets/application.js
+++ b/site/src/assets/application.js
@@ -13,6 +13,7 @@ import stickyNav from './partials/sticky.js'
 import theme from './partials/theme.js'
 import tocDrawer from './partials/toc.js'
 import tocHeight from './partials/toc-height.js'
+import tocScroll from './partials/toc-scroll.js'
 
 export default () => {
   sidebarScroll()
@@ -21,4 +22,5 @@ export default () => {
   theme()
   tocDrawer()
   tocHeight()
+  tocScroll()
 }

--- a/site/src/assets/partials/toc-scroll.js
+++ b/site/src/assets/partials/toc-scroll.js
@@ -1,0 +1,46 @@
+// NOTICE: Internal docs helpers — not shipped in Bootstrap; not for reuse.
+
+/*
+ * JavaScript for Bootstrap's docs (https://getbootstrap.com/)
+ * Copyright 2011-2026 The Bootstrap Authors
+ * Licensed under the Creative Commons Attribution 3.0 Unported License.
+ * For details, see https://creativecommons.org/licenses/by/3.0/.
+ */
+
+export default () => {
+  const sidebar = document.querySelector('#bdTocSidebar')
+
+  if (!sidebar) {
+    return
+  }
+
+  // Length of the fade at each edge, in pixels.
+  const fade = 24
+
+  let ticking = false
+
+  const update = () => {
+    ticking = false
+
+    const { scrollTop, scrollHeight, clientHeight } = sidebar
+    const maxScroll = scrollHeight - clientHeight
+
+    // No overflow → no fade at either edge.
+    const top = maxScroll > 1 ? Math.min(scrollTop, fade) : 0
+    const bottom = maxScroll > 1 ? Math.min(maxScroll - scrollTop, fade) : 0
+
+    sidebar.style.setProperty('--bd-toc-fade-top', `${top}px`)
+    sidebar.style.setProperty('--bd-toc-fade-bottom', `${bottom}px`)
+  }
+
+  const requestUpdate = () => {
+    if (!ticking) {
+      ticking = true
+      window.requestAnimationFrame(update)
+    }
+  }
+
+  update()
+  sidebar.addEventListener('scroll', requestUpdate, { passive: true })
+  window.addEventListener('resize', requestUpdate, { passive: true })
+}

--- a/site/src/scss/_toc.scss
+++ b/site/src/scss/_toc.scss
@@ -86,10 +86,6 @@
       min-height: 0;
       margin-bottom: auto;
       overflow-y: auto;
-
-      // Fade the top and bottom edges while the list scrolls. The fade lengths
-      // are driven by `toc-scroll.js`; both are 0 at rest so nothing is clipped
-      // when there is no overflow.
       mask-image:
         linear-gradient(
           to bottom,

--- a/site/src/scss/_toc.scss
+++ b/site/src/scss/_toc.scss
@@ -60,6 +60,10 @@
     }
 
     .nav-link {
+      align-items: flex-start;
+      line-height: 1.35;
+      text-wrap: pretty;
+      white-space: normal;
       border-inline-start: .125rem solid transparent;
       @include border-radius(0);
 
@@ -70,6 +74,7 @@
 
       code {
         font: inherit;
+        overflow-wrap: anywhere;
       }
     }
   }
@@ -81,6 +86,18 @@
       min-height: 0;
       margin-bottom: auto;
       overflow-y: auto;
+
+      // Fade the top and bottom edges while the list scrolls. The fade lengths
+      // are driven by `toc-scroll.js`; both are 0 at rest so nothing is clipped
+      // when there is no overflow.
+      mask-image:
+        linear-gradient(
+          to bottom,
+          transparent 0,
+          #000 var(--bd-toc-fade-top, 0),
+          #000 calc(100% - var(--bd-toc-fade-bottom, 0)),
+          transparent 100%
+        );
     }
 
     @include media-breakpoint-down(lg) {


### PR DESCRIPTION
- Wrap long TOC headings instead of clipping them.
- Fade the TOC list at the scroll edges when it overflows.