### PR TITLE
Fix TypeError when a component is disposed mid-transition

### DIFF
--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -47,7 +47,16 @@ class BaseComponent extends Config {
 
   // Private
   _queueCallback(callback, element, isAnimated = true) {
-    executeAfterTransition(callback, element, isAnimated)
+    executeAfterTransition(() => {
+      // `dispose()` nulls every property of the instance, but it cannot cancel a
+      // callback already queued on a transition. Skip it rather than let it run
+      // against a disposed instance and throw
+      if (!this._element) {
+        return
+      }
+
+      callback()
+    }, element, isAnimated)
   }
 
   _getConfig(config) {

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -443,6 +443,65 @@ describe('Tooltip', () => {
       tooltip2.dispose()
       expect(tooltipWithoutTitleEl.getAttribute('title')).toBeNull()
     })
+
+    it('should not run a callback queued by hide() when disposed mid-transition', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+        const hiddenSpy = jasmine.createSpy('hidden')
+        const errorSpy = jasmine.createSpy('error')
+
+        tooltipEl.addEventListener('hidden.bs.tooltip', hiddenSpy)
+
+        tooltipEl.addEventListener('shown.bs.tooltip', () => {
+          window.addEventListener('error', errorSpy)
+
+          // `hide()` queues its completion callback on the fade transition,
+          // `dispose()` then nulls every property before that callback runs
+          tooltip.hide()
+          tooltip.dispose()
+
+          setTimeout(() => {
+            window.removeEventListener('error', errorSpy)
+
+            expect(errorSpy).not.toHaveBeenCalled()
+            expect(hiddenSpy).not.toHaveBeenCalled()
+            resolve()
+          }, 50)
+        })
+
+        tooltip.show()
+      })
+    })
+
+    it('should not run a callback queued by show() when disposed mid-transition', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+        const shownSpy = jasmine.createSpy('shown')
+        const errorSpy = jasmine.createSpy('error')
+
+        tooltipEl.addEventListener('shown.bs.tooltip', shownSpy)
+        window.addEventListener('error', errorSpy)
+
+        tooltip.show()
+        tooltip.dispose()
+
+        setTimeout(() => {
+          window.removeEventListener('error', errorSpy)
+
+          expect(errorSpy).not.toHaveBeenCalled()
+          expect(shownSpy).not.toHaveBeenCalled()
+          // the queued callback must not write back onto the disposed instance
+          expect(tooltip._isHovered).toBeNull()
+          resolve()
+        }, 50)
+      })
+    })
   })
 
   describe('show', () => {


### PR DESCRIPTION
### Description

Skip a component's queued transition-completion callback if the instance was disposed before the transition finished.

`dispose()` nulls every property on the instance but cannot cancel a callback already queued via executeAfterTransition as that helper registers a transitionend listener plus a setTimeout fallback, and neither can be cancelled. The callback then runs against a gutted instance and throws.

This deliberately does not null-guard `Tooltip._isWithActiveTrigger()`, the fix proposed in #37474. As noted there, that is only a defensive patch, and it just relocates the crash two lines down to `this._element.removeAttribute('aria-describedby')`. Better the queued callback not run at all.

Since every component routes transition completion through `BaseComponent._queueCallback`, guarding that single method fixes it for all of them at once. `_element` is already nulled by `dispose()`, so it doubles as the disposed flag and no new state, and `executeAfterTransition`'s signature is untouched. Nothing leaks by skipping the callback: Modal and Offcanvas already dispose their backdrop and focustrap explicitly in their own `dispose()`.

### Motivation & Context

Fixes the long-standing `Uncaught TypeError: Cannot convert undefined or null to object from Tooltip._isWithActiveTrigger()` when a component is disposed mid-transition. Reported repeatedly since 2022 and typically worked around with a setTimeout before `dispose()`.

`dispose()` is public API with no documented restriction against calling it during a transition, and the common trigger is not misuse: a MutationObserver disposing a tooltip whose trigger element was just removed from the DOM has no way to know a fade is still in flight.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42858--twbs-bootstrap.netlify.app/>

### Related issues

Closes #37474 (if reopened, I have added a comment/request there)
Related: #39743