### PR TITLE
Move Linkinator to a dedicated monthly workflow

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -108,7 +108,6 @@
     "Libsass",
     "lightboxes",
     "lightningcss",
-    "linkinator",
     "llms",
     "llmstxt",
     "longdesc",

--- a/.cspell.json
+++ b/.cspell.json
@@ -108,6 +108,7 @@
     "Libsass",
     "lightboxes",
     "lightningcss",
+    "linkinator",
     "llms",
     "llmstxt",
     "longdesc",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,23 +38,3 @@ jobs:
 
       - name: Validate HTML
         run: npm run docs-html-validate
-
-      - name: Run linkinator
-        uses: JustinBeckwith/linkinator-action@36a0bfbfecd5e237e8f8531537a693616c505faf # v2.4.5
-        with:
-          paths: _site
-          recurse: true
-          verbosity: error
-          # github.com URLs are skipped because they will be broken until the next release is published.
-          skip: >-
-            ^http://localhost
-            ^https://www.reddit.com
-            ^https://medium.com
-            ^https://getbootstrap.com/docs/6.0
-            ^https://github.com/twbs/bootstrap/blob/v6.0.0-alpha1
-            ^https://github.com/twbs/bootstrap/tree/v5-dev
-            ^https://github.com/twbs/bootstrap/releases/download/v6.0.0-alpha1/
-            ^https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1
-            ^https://github.com/twbs/bootstrap/archive/v6.0.0-alpha1.zip
-            ^https://github.com/twbs/bootstrap/tree/main/skills
-            ^https://github.com/twbs/bootstrap/blob/main/scss/forms/_combobox.scss

--- a/.github/workflows/linkinator.yml
+++ b/.github/workflows/linkinator.yml
@@ -1,0 +1,55 @@
+name: Linkinator
+
+on:
+  schedule:
+    - cron: "0 4 1 * *"
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 2
+
+permissions:
+  contents: read
+
+jobs:
+  linkinator:
+    runs-on: ubuntu-latest
+    if: github.repository == 'twbs/bootstrap'
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs-build
+
+      - name: Run linkinator
+        uses: JustinBeckwith/linkinator-action@36a0bfbfecd5e237e8f8531537a693616c505faf # v2.4.5
+        with:
+          paths: _site
+          recurse: true
+          verbosity: error
+          # github.com URLs are skipped because they will be broken until the next release is published.
+          skip: >-
+            ^http://localhost
+            ^https://www.reddit.com
+            ^https://medium.com
+            ^https://getbootstrap.com/docs/6.0
+            ^https://github.com/twbs/bootstrap/blob/v6.0.0-alpha1
+            ^https://github.com/twbs/bootstrap/tree/v5-dev
+            ^https://github.com/twbs/bootstrap/releases/download/v6.0.0-alpha1/
+            ^https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1
+            ^https://github.com/twbs/bootstrap/archive/v6.0.0-alpha1.zip
+            ^https://github.com/twbs/bootstrap/tree/main/skills
+            ^https://github.com/twbs/bootstrap/blob/main/scss/forms/_combobox.scss


### PR DESCRIPTION
Linkinator checks external links on every docs build.

- External sites go down or become unreachable sometimes, which fails the check for reasons outside our control. See https://github.com/twbs/bootstrap/actions/runs/32747951867.
- It sends many requests per docs build for external links.
- Users already report broken links when they find them.
- Astro's `astro-check-links` plugin already validates internal links at build time.

---

**Edit**: After coliff comment, this PR doesn't remove Linkinator step but does the following:

- Remove the Linkinator step from `docs.yml` as it ran on every push/PR, which isn't necessary for a link checker
- Add `.github/workflows/linkinator.yml`: builds the docs site and runs Linkinator against it
- Schedule it for the 1st of each month at 04:00 UTC (05:00 in France, CET)
- Add `workflow_dispatch` so it can also be triggered manually from the GitHub UI
- Restore linkinator in `.cspell.json`, still needed for the new workflow

> [!WARNING]
> It'll only be testable, it'll only work, whenever `v6-dev` will be the default branch of this repository