### PR TITLE
Add an accordion-gap modifier

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -24,6 +24,7 @@ $accordion-tokens: defaults(
     --accordion-border-color: var(--border-color),
     --accordion-border-width: var(--border-width),
     --accordion-border-radius: var(--accordion-radius, var(--radius-7)),
+    --accordion-gap: 0,
     --accordion-btn-color: var(--fg-2),
     --accordion-btn-bg: var(--bg-body),
     --accordion-btn-icon-width: 1rem,
@@ -117,7 +118,7 @@ $accordion-tokens: defaults(
 
     &:not(:first-of-type) {
       // border-block-start: 0;
-      margin-top: calc(-1 * var(--accordion-border-width));
+      margin-block-start: calc(-1 * var(--accordion-border-width));
     }
 
     // Only set a border-radius on the last item if the accordion is collapsed
@@ -176,6 +177,34 @@ $accordion-tokens: defaults(
     --accordion-border-radius: var(--radius-5);
     --accordion-font-size: var(--font-size-sm);
     // scss-docs-end accordion-sm-css-vars
+  }
+
+
+  // Gapped accordion
+  //
+  // Put the gap on the accordion, not the panel. Flex gap stays constant, so
+  // it does not join the block-size transition. Overflow clip holds a stable
+  // radius on every item, so corners do not retarget while the panel opens.
+
+  .accordion-gap {
+    // scss-docs-start accordion-gap-css-vars
+    --accordion-gap: var(--spacer-2);
+    // scss-docs-end accordion-gap-css-vars
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--accordion-gap);
+
+    > .accordion-item {
+      margin-block-start: 0;
+      overflow: clip;
+      @include border-radius(var(--accordion-border-radius));
+
+      > .accordion-header,
+      > .accordion-body {
+        @include border-radius(0);
+      }
+    }
   }
 
 

--- a/site/src/content/docs/components/accordion.mdx
+++ b/site/src/content/docs/components/accordion.mdx
@@ -151,6 +151,46 @@ Add `.accordion-flush` to remove some borders and rounded corners to render acco
     <!-- Accordion items here -->
   </div>`} />
 
+## Gap
+
+Add `.accordion-gap` to put space between accordion items. Each item is a separate rounded card.
+
+The gap lives on the accordion, not the panel. The panel still animates only its `block-size`, so the open and close transition stays smooth.
+
+<Example code={`<div class="accordion accordion-gap">
+    <details class="accordion-item" name="accordionGapExample" open>
+      <summary class="accordion-header">
+        Accordion Item #1
+        <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+      </summary>
+      <div class="accordion-body">
+        <strong>This is the first item’s accordion body.</strong> The <code>.accordion-gap</code> class spaces items apart. Each item keeps a full border radius while the panel opens and closes.
+      </div>
+    </details>
+    <details class="accordion-item" name="accordionGapExample">
+      <summary class="accordion-header">
+        Accordion Item #2
+        <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+      </summary>
+      <div class="accordion-body">
+        <strong>This is the second item’s accordion body.</strong> The gap does not change during the transition, so adjacent items do not jump.
+      </div>
+    </details>
+    <details class="accordion-item" name="accordionGapExample">
+      <summary class="accordion-header">
+        Accordion Item #3
+        <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+      </summary>
+      <div class="accordion-body">
+        <strong>This is the third item’s accordion body.</strong> Override <code>--accordion-gap</code> to change the space between items.
+      </div>
+    </details>
+  </div>`} customMarkup={`<div class="accordion accordion-gap"><!--[!code highlight]-->
+    <!-- Accordion items here -->
+  </div>`} />
+
+<ScssDocs name="accordion-gap-css-vars" file="scss/_accordion.scss" />
+
 ## Always open
 
 Omit the `name` attribute on each `<details>` element to allow multiple accordion items to be open simultaneously.


### PR DESCRIPTION
- Add an `.accordion-gap` modifier that spaces accordion items apart as separate rounded cards.
- Put the space in a flex `gap` on the accordion rather than a margin on the panel. A flex gap does not join the `block-size` transition, so adjacent items no longer jump while a panel opens.
- Clip item overflow and keep a full border radius on every item, so corners do not retarget mid-transition.
- Add the `--accordion-gap` token, defaulting to `0` and to `--spacer-2` under `.accordion-gap`.
- Swap the item `margin-top` for the logical `margin-block-start`.
- Document the modifier with an example and a `ScssDocs` block.
