### PR TITLE
Tighten theme mix, shades, and border docs

### DIFF
--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -56,7 +56,7 @@ $colors: defaults(
 // scss-docs-end colors-map
 
 // scss-docs-start color-mix-options
-$color-mix-space: lab !default;
+$color-mix-space: oklch !default;
 $tint-color: var(--white) !default;
 $shade-color: var(--black) !default;
 
@@ -82,8 +82,8 @@ $color-shades: defaults(
     "700": 32%,
     "800": 48%,
     "900": 64%,
-    "950": 76%,
-    "975": 88%,
+    "950": 70%,
+    "975": 76%,
   ),
   $color-shades
 );

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -220,8 +220,8 @@ $tab-pane-tokens: defaults(
 
     .nav-link.active,
     .show > .nav-link {
-      color: var(--nav-pills-link-active-color);
-      @include gradient-bg(var(--nav-pills-link-active-bg));
+      color: var(--theme-contrast, var(--nav-pills-link-active-color));
+      @include gradient-bg(var(--theme-bg, var(--nav-pills-link-active-bg)));
     }
   }
 

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -245,7 +245,7 @@ $theme-borders: defaults(
     "bg": var(--bg-body),
     "body": light-dark(var(--gray-300), var(--gray-800)),
     "muted": light-dark(var(--gray-200), var(--gray-800)),
-    "subtle": light-dark(color-mix(in oklch, var(--gray-100), var(--gray-200)), var(--gray-900)),
+    "subtle": light-dark(color-mix(in oklch, var(--gray-100), var(--gray-200)), color-mix(in oklch, var(--gray-800), var(--gray-900))),
     "emphasized": light-dark(var(--gray-400), var(--gray-600)),
     "white": var(--white),
     "black": var(--black),

--- a/site/src/components/shortcodes/Swatch.astro
+++ b/site/src/components/shortcodes/Swatch.astro
@@ -156,6 +156,50 @@ const displayCssVar = bg
 }
 
 <script>
+  // Return the arguments inside a function call, e.g. light-dark(a, b) => "a, b".
+  function extractArgs(value: string, fnName: string): string | null {
+    const start = value.indexOf(`${fnName}(`)
+    if (start === -1) return null
+
+    const contentStart = start + fnName.length + 1
+    let depth = 0
+    for (let i = contentStart - 1; i < value.length; i++) {
+      if (value[i] === '(') depth++
+      else if (value[i] === ')') {
+        depth--
+        if (depth === 0) return value.slice(contentStart, i)
+      }
+    }
+    return null
+  }
+
+  // Split a comma list at the top level, ignoring commas nested in parens.
+  function splitTopLevel(input: string): string[] {
+    const parts: string[] = []
+    let depth = 0
+    let current = ''
+    for (const char of input) {
+      if (char === '(') depth++
+      else if (char === ')') depth--
+      if (char === ',' && depth === 0) {
+        parts.push(current.trim())
+        current = ''
+      } else {
+        current += char
+      }
+    }
+    if (current.trim()) parts.push(current.trim())
+    return parts
+  }
+
+  // Compact for display: unwrap var(--token) to --token, collapse spaces.
+  function prettifyValue(value: string): string {
+    return value
+      .replace(/var\(\s*(--[\w-]+)\s*\)/g, '$1')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+
   // Handle dynamic CSS variable display with light-dark() function support
   document.addEventListener('DOMContentLoaded', () => {
     const cssVarElements = document.querySelectorAll('.css-var[data-css-var]')
@@ -191,30 +235,19 @@ const displayCssVar = bg
         }
 
         if (rawValue) {
-          // Check if the value contains light-dark function
-          if (rawValue.includes('light-dark(')) {
-            // Parse the light-dark function to extract light and dark values
-            const lightDarkMatch = rawValue.match(/light-dark\(([^,]+),\s*(.+)\)$/)
-            if (lightDarkMatch) {
-              const lightValue = lightDarkMatch[1].trim()
-              const darkValue = lightDarkMatch[2].trim()
+          const args = rawValue.includes('light-dark(') ? extractArgs(rawValue, 'light-dark') : null
+          const parts = args ? splitTopLevel(args) : []
 
-              // Update the spans with the parsed values
-              const lightSpan = element.querySelector('.css-var-light')
-              const darkSpan = element.querySelector('.css-var-dark')
+          if (parts.length === 2) {
+            // Show the light value in light mode and the dark value in dark mode
+            const lightSpan = element.querySelector('.css-var-light')
+            const darkSpan = element.querySelector('.css-var-dark')
 
-              if (lightSpan) lightSpan.textContent = lightValue
-              if (darkSpan) darkSpan.textContent = darkValue
-            } else {
-              // Fallback: show the full value
-              element.innerHTML = `<span class="css-var-light">${rawValue}</span>`
-            }
-          } else if (rawValue.includes('color-mix(')) {
-            // Handle color-mix functions - show the full function
-            element.innerHTML = `<span class="css-var-light">${rawValue}</span>`
+            if (lightSpan) lightSpan.textContent = prettifyValue(parts[0])
+            if (darkSpan) darkSpan.textContent = prettifyValue(parts[1])
           } else {
-            // Single value - show it in both light and dark spans
-            element.innerHTML = `<span class="css-var-light">${rawValue}</span>`
+            // Single value (including color-mix) - show it as-is
+            element.innerHTML = `<span class="css-var-light">${prettifyValue(rawValue)}</span>`
           }
         } else {
           // Fallback: show the variable name

--- a/site/src/content/docs/customize/theme.mdx
+++ b/site/src/content/docs/customize/theme.mdx
@@ -18,28 +18,6 @@ export const themeTokens = [
   'contrast'
 ]
 
-export const themeBgs = [
-  'body',
-  'secondary',
-  'subtle',
-  'muted',
-  'white',
-  'black',
-  'transparent',
-  'inherit',
-]
-
-export const themeFgs = [
-  'body',
-  'secondary',
-  'subtle',
-  'muted',
-  'white',
-  'black',
-  'transparent',
-  'inherit',
-]
-
 ## How it works
 
 Theme colors are defined in the `$theme-colors` Sass map. This map is used to generate our theme color values. You’ll find these values in the `_theme.scss` file. These are where we define our design tokens for Bootstrap, across both light and dark color modes.
@@ -105,13 +83,13 @@ Not all colors can be used for all purposes due to accessibility, color contrast
 - `border` works best with `subtle`, but can be used with `muted`
 
 <Example code={`<div class="theme-primary vstack gap-3">
-    <div style="color: var(--bs-theme-contrast); background: var(--bs-theme-bg);" class="p-3 rounded-3">
+    <div style="color: var(--bs-theme-contrast); background: var(--bs-theme-bg);" class="p-3 rounded-5">
       Example element with theme color
     </div>
-    <div style="color: var(--bs-theme-fg-emphasis); background: var(--bs-theme-bg-muted); border: 1px solid var(--bs-theme-border);" class="p-3 rounded-3">
+    <div style="color: var(--bs-theme-fg-emphasis); background: var(--bs-theme-bg-muted); border: 1px solid var(--bs-theme-border);" class="p-3 rounded-5">
       Example element with theme color
     </div>
-    <div style="color: var(--bs-theme-fg); background: var(--bs-theme-bg-subtle); border: 1px solid var(--bs-theme-border);" class="p-3 rounded-3">
+    <div style="color: var(--bs-theme-fg); background: var(--bs-theme-bg-subtle); border: 1px solid var(--bs-theme-border);" class="p-3 rounded-5">
       Example element with theme color
     </div>
   </div>`} />
@@ -162,10 +140,13 @@ Border colors have similar levels, but different naming.
 <BsTable>
 | Border | Default value | Description |
 | --- | --- | --- |
-| `null` | <Swatch bg="border" size="inline" /> | Default border color |
-| `muted` | <Swatch bg="border-muted" size="inline" /> | Muted border color |
-| `subtle` | <Swatch bg="border-subtle" size="inline" /> | Subtle border color |
-| `emphasized` | <Swatch bg="border-emphasized" size="inline" /> | Emphasized border color |
+| `bg` | <Swatch bg="border-bg" size="inline" /> | Border that matches the body background color |
+| `body` | <Swatch bg="border-body" size="inline" /> | Default border color for body content |
+| `muted` | <Swatch bg="border-muted" size="inline" /> | Muted, lower contrast border color, often used for disabled states |
+| `subtle` | <Swatch bg="border-subtle" size="inline" /> | Subtle, lowest contrast border color |
+| `emphasized` | <Swatch bg="border-emphasized" size="inline" /> | Emphasized, higher contrast border color |
+| `white` | <Swatch bg="border-white" size="inline" /> | Pure white border color |
+| `black` | <Swatch bg="border-black" size="inline" /> | Pure black border color |
 </BsTable>
 
 ### Examples
@@ -180,16 +161,19 @@ Not all colors can be used for all purposes due to accessibility, color contrast
 Here are some examples showing them together. Note
 
 <Example code={`<div class="vstack gap-3">
-    <div class="p-3 rounded-3 bg-body fg-body border">
+    <div class="p-3 rounded-5 bg-body fg-body border border-subtle">
+      fg-body on bg-body with border-subtle
+    </div>
+    <div class="p-3 rounded-5 bg-body fg-body border">
       fg-body on bg-body
     </div>
-    <div class="p-3 rounded-3 bg-1 fg-3 border">
+    <div class="p-3 rounded-5 bg-1 fg-3 border">
       fg-3 on bg-1
     </div>
-    <div class="p-3 rounded-3 bg-2 fg-2 border">
+    <div class="p-3 rounded-5 bg-2 fg-2 border">
       fg-2 on bg-2
     </div>
-    <div class="p-3 rounded-3 bg-3 fg-1 border">
+    <div class="p-3 rounded-5 bg-3 fg-1 border">
       fg-1 on bg-3
     </div>
   </div>`} />
@@ -203,7 +187,7 @@ By default, `color-scheme: light dark` is set on the `:root` element, meaning Bo
 Here’s the same set of components rendered in both light and dark modes side by side. Note the use of `.bg-body` for the backgrounds. Without it, the light mode demo wouldn’t have a white background—just light mode components on a dark background.
 
 <Example class="p-0 overflow-hidden" code={`<div class="row g-0">
-    <div class="md:col-6 vstack gap-3 p-4 bg-body" data-bs-theme="light">
+    <div class="md:col-6 vstack gap-3 p-4 bg-body fg-body" data-bs-theme="light"><!-- [!code highlight] -->
       <h6 class="fw-semibold">Light mode</h6>
       <div class="card">
         <div class="card-body">
@@ -215,14 +199,14 @@ Here’s the same set of components rendered in both light and dark modes side b
       <input type="text" class="form-control" placeholder="Form control">
       <div class="form-field">
         <input type="checkbox" id="checkLabel" class="check" />
-        <label class="form-label" for="checkLabel">Example new checkbox</label>
+        <label for="checkLabel">Example new checkbox</label>
       </div>
       <div class="vstack gap-2">
         <button type="button" class="btn-solid theme-primary">Primary</button>
         <button type="button" class="btn-subtle theme-secondary">Secondary</button>
       </div>
     </div>
-    <div class="md:col-6 vstack gap-3 p-4 bg-body" data-bs-theme="dark">
+    <div class="md:col-6 vstack gap-3 p-4 bg-body fg-body" data-bs-theme="dark"><!-- [!code highlight] -->
       <h6 class="fw-semibold">Dark mode</h6>
       <div class="card">
         <div class="card-body">
@@ -234,7 +218,7 @@ Here’s the same set of components rendered in both light and dark modes side b
       <input type="text" class="form-control" placeholder="Form control">
       <div class="form-field">
         <input type="checkbox" id="checkDarkLabel" class="check" />
-        <label class="form-label" for="checkDarkLabel">Example new checkbox</label>
+        <label for="checkDarkLabel">Example new checkbox</label>
       </div>
       <div class="vstack gap-2">
         <button type="button" class="btn-solid theme-primary">Primary</button>
@@ -273,7 +257,7 @@ With theme utilities, you can apply a theme color to an element with a single cl
 
 And you can apply a theme color utility to a container and any theme-aware children will inherit the theme color.
 
-<Example code={`<div class="vstack gap-3 theme-primary">
+<Example code={`<div class="vstack gap-3 theme-primary"><!-- [!code highlight] -->
     <div class="alert"><p>Primary alert</p></div>
     <div>
       <button type="button" class="btn-solid">Primary button</button>
@@ -292,13 +276,13 @@ This also means you can override a container’s theme color with another theme 
 <Example code={`<div class="vstack gap-3 theme-primary">
     <div class="alert"><p>Primary alert</p></div>
     <div>
-      <button type="button" class="btn-solid theme-emphasis">Emphasis button</button>
+      <button type="button" class="btn-solid theme-inverse">Inverse button</button><!-- [!code highlight] -->
       <button type="button" class="btn-outline">Primary outline button</button>
-      <button type="button" class="btn-subtle theme-danger">Danger subtle button</button>
+      <button type="button" class="btn-subtle theme-danger">Danger subtle button</button><!-- [!code highlight] -->
       <button type="button" class="btn-text">Primary text button</button>
     </div>
     <div>
-      <span class="badge theme-success">Success badge</span>
+      <span class="badge theme-success">Success badge</span><!-- [!code highlight] -->
       <span class="badge badge-subtle">Primary subtle badge</span>
     </div>
   </div>`} />
@@ -314,7 +298,7 @@ Use `.theme-reset` on a nested container to stop inheriting those tokens. Theme-
       <span class="badge">Primary badge</span>
     </div>
 
-    <div class="theme-reset vstack gap-3"><!-- [!code highlight] -->
+    <div class="vstack gap-3 theme-reset"><!-- [!code highlight] -->
       <div class="alert"><p>Default alert</p></div>
       <div>
         <button type="button" class="btn-solid">Default button</button>


### PR DESCRIPTION
- Switch `$color-mix-space` from `lab` to `oklch` so tints and shades hold a more even lightness across the palette.
- Pull the `950` and `975` shades back from 76%/88% to 70%/76%. The darkest steps had collapsed together.
- Mix the dark mode `--border-subtle` from `gray-800` and `gray-900`. Plain `gray-900` sat too close to the dark body background to read as a border.
- Let an active `.nav-pills` link follow `--theme-bg` and `--theme-contrast`, falling back to the existing pill tokens, so a theme utility on a pill nav takes effect.
- Fix `Swatch.astro`, which split `light-dark()` on the first comma and fell back to the raw string whenever a nested `color-mix()` contained one. It now matches parens and unwraps `var(--token)` for display.
- Document the border tokens that already shipped (`bg`, `body`, `white`, `black`) and drop two unused arrays from the theme page.
