### PR TITLE
Refresh the homepage masthead

### DIFF
--- a/site/src/components/home/MastHead.astro
+++ b/site/src/components/home/MastHead.astro
@@ -25,7 +25,9 @@ import CodeCopy from '@components/shortcodes/CodeCopy.astro'
           Bootstrap 6 has been rebuilt for today's web as a framework-agnostic design toolkit that anyone—human or AI,
           novice or pro—can use to build anything. New standards, new components, an updated visual design, CSS-first
           theming, and more powerful JavaScript plugins.
-          <br/><a href="https://blog.getbootstrap.com/2026/07/15/bootstrap-6/" class="underline-30">Read the v6 announcement post.</a>
+          <br /><a href="https://blog.getbootstrap.com/2026/07/15/bootstrap-6/" class="underline-30"
+            >Read the v6 announcement post.</a
+          >
         </p>
       </div>
       <div class="d-flex flex-column md:flex-row md:align-items-stretch md:my-2 gap-2">
@@ -44,9 +46,8 @@ import CodeCopy from '@components/shortcodes/CodeCopy.astro'
       <div class="d-flex flex-column md:flex-row gap-2 fg-2">
         <span>Currently v{getConfig().current_version}</span>
         <span class="d-none md:d-inline">&middot;</span>
-        <a
-          href="https://getbootstrap.com/docs/5.3/"
-          class="theme-secondary underline-50 underline-secondary">Bootstrap 5 docs</a
+        <a href="https://getbootstrap.com/docs/5.3/" class="theme-secondary underline-50 underline-secondary"
+          >Bootstrap 5 docs</a
         >
         <span class="d-none md:d-inline">&middot;</span>
         <a href="/docs/versions/" class="theme-secondary underline-50 underline-secondary text-nowrap">All releases</a>

--- a/site/src/components/home/MastHead.astro
+++ b/site/src/components/home/MastHead.astro
@@ -8,7 +8,7 @@ import CodeCopy from '@components/shortcodes/CodeCopy.astro'
 
 <div class="bd-masthead mb-3" id="content">
   <div class="2xl:container bd-gutter">
-    <div class="md:col-8 mx-auto d-flex flex-column gap-5 align-items-center text-center">
+    <div class="lg:col-10 mx-auto d-flex flex-column gap-5 align-items-center text-center">
       <a
         class="badge badge-subtle badge-lg fs-md fw-normal theme-warning border border-bg border-50 rounded-pill gap-1"
         href="https://www.herodevs.com/support/nes-bootstrap?utm_source=Bootstrap_site&utm_medium=Banner&utm_campaign=v3and4_eol"
@@ -25,30 +25,32 @@ import CodeCopy from '@components/shortcodes/CodeCopy.astro'
           Bootstrap 6 has been rebuilt for today's web as a framework-agnostic design toolkit that anyone—human or AI,
           novice or pro—can use to build anything. New standards, new components, an updated visual design, CSS-first
           theming, and more powerful JavaScript plugins.
-          <!-- <br/><a href="https://blog.getbootstrap.com/2026/07/15/bootstrap-6/" class="underline-30">Read the v6 announcement post.</a> -->
+          <br/><a href="https://blog.getbootstrap.com/2026/07/15/bootstrap-6/" class="underline-30">Read the v6 announcement post.</a>
         </p>
       </div>
-      <div class="d-flex flex-column lg:flex-row md:align-items-stretch md:my-2 gap-2">
+      <div class="d-flex flex-column md:flex-row md:align-items-stretch md:my-2 gap-2">
         <CodeCopy code={`npm i bootstrap@${getConfig().current_version}`} />
-        <a
-          href={getVersionedDocsPath('getting-started/install')}
-          class="btn-solid btn-styled theme-accent btn-lg justify-content-center fw-medium"
-        >
-          <svg class="bi" aria-hidden="true"><use href="#book-half"></use></svg>
-          Read the docs
-        </a>
         <ForAgents />
+        <div class="d-flex flex-stretch shadow shadow-accent rounded-7">
+          <a
+            href={getVersionedDocsPath('getting-started/install')}
+            class="btn-solid btn-styled theme-accent btn-lg w-100 fw-medium"
+          >
+            <svg class="bi" aria-hidden="true"><use href="#book-half"></use></svg>
+            Read the docs
+          </a>
+        </div>
       </div>
-      <p class="fg-2 mb-0">
-        Currently <strong>v{getConfig().current_version}</strong>
-        <span class="px-1">&middot;</span>
+      <div class="d-flex flex-column md:flex-row gap-2 fg-2">
+        <span>Currently v{getConfig().current_version}</span>
+        <span class="d-none md:d-inline">&middot;</span>
         <a
-          href={getVersionedDocsPath('getting-started/install')}
-          class="theme-secondary underline-50 underline-secondary">Download</a
+          href="https://getbootstrap.com/docs/5.3/"
+          class="theme-secondary underline-50 underline-secondary">Bootstrap 5 docs</a
         >
-        <span class="px-1">&middot;</span>
+        <span class="d-none md:d-inline">&middot;</span>
         <a href="/docs/versions/" class="theme-secondary underline-50 underline-secondary text-nowrap">All releases</a>
-      </p>
+      </div>
       <Ads />
     </div>
   </div>


### PR DESCRIPTION
- Link the v6 announcement post, which is now live, and widen the headline column to `lg:col-10` so the lead paragraph breaks over fewer lines.
- Group the install command, the agents link, and the docs button on one row from the `md` breakpoint, and wrap the docs button in an accent shadow so it reads as the primary action.
- Point the second footer link at the Bootstrap 5 docs. It previously repeated the install page that the docs button already opens.
- Use the absolute `https://getbootstrap.com/docs/5.3/` URL, matching `Versions.astro`. A root-relative `/docs/5.3/` fails the broken-link checker during `docs-build`, since the v5 docs are not part of this build.
- Stack the footer meta links on small screens and hide the separators there.
