### PR TITLE
docs(grid): document .col-auto in variable-width content

### DIFF
--- a/site/src/content/docs/layout/columns.mdx
+++ b/site/src/content/docs/layout/columns.mdx
@@ -277,7 +277,7 @@ In addition to column clearing at responsive breakpoints, you may need to reset 
 
 #### Margin utilities
 
-With the move to flexbox in v4, you can use margin utilities like `.me-auto` to force sibling columns away from one another.
+With the move to flexbox in v4, you can use margin utilities like `.me-auto` to force sibling columns away from one another, including with [variable-width columns]([[docsref:/layout/grid#variable-width-content]]) such as `.col-auto`.
 
 <Example class="bd-example-row" code={`<div class="container text-center">
     <div class="row">

--- a/site/src/content/docs/layout/grid.mdx
+++ b/site/src/content/docs/layout/grid.mdx
@@ -176,7 +176,7 @@ Auto-layout for flexbox grid columns also means you can set the width of one col
 
 ### Variable width content
 
-Use `col-{breakpoint}-auto` classes to size columns based on the natural width of their content.
+Use `.col-auto` and `col-{breakpoint}-auto` classes to size columns based on the natural width of their content across all viewports or at specific breakpoints.
 
 <Example class="bd-example-row" code={`<div class="container text-center">
     <div class="row justify-content-md-center">
@@ -194,7 +194,7 @@ Use `col-{breakpoint}-auto` classes to size columns based on the natural width o
       <div class="col">
         1 of 3
       </div>
-      <div class="col-md-auto">
+      <div class="col-auto">
         Variable width content
       </div>
       <div class="col col-lg-2">


### PR DESCRIPTION
### Description

- Explicitly mentions `.col-auto` alongside `col-{breakpoint}-auto` in the **Variable width content** section of the Grid documentation (`site/src/content/docs/layout/grid.mdx`).
- Updates the variable-width code example to demonstrate `.col-auto` alongside `.col-md-auto`.
- Updates the **Margin utilities** section in the Columns documentation (`site/src/content/docs/layout/columns.mdx`) to clarify usage with variable-width columns like `.col-auto`.

### Motivation & Context

In the grid documentation under "Variable width content", the text previously only mentioned `col-{breakpoint}-auto` classes and only demonstrated `.col-md-auto`. However, `.col-auto` was not explicitly introduced or searchable in the section, yet was used in subsequent examples such as the Columns margin utilities section.

Explicitly documenting `.col-auto` makes it clear that the breakpoint-less variant exists for sizing columns based on natural content width across all viewports.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/docs/5.3/layout/grid/#variable-width-content>
- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/docs/5.3/layout/columns/#margin-utilities>

### Related issues

Closes #36978
