### PR TITLE
Fixes to Example navbars-drawer

### DIFF
--- a/site/src/assets/examples/navbars-drawer/index.astro
+++ b/site/src/assets/examples/navbars-drawer/index.astro
@@ -18,7 +18,7 @@ export const extra_css = ['navbars-drawer.css']
           <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
         </div>
         <div class="drawer-body">
-          <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+          <ul class="navbar-nav pe-3">
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="#">Home</a>
             </li>
@@ -58,7 +58,7 @@ export const extra_css = ['navbars-drawer.css']
           <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
         </div>
         <div class="drawer-body">
-          <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+          <ul class="navbar-nav pe-3">
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="#">Home</a>
             </li>
@@ -98,7 +98,7 @@ export const extra_css = ['navbars-drawer.css']
           <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
         </div>
         <div class="drawer-body">
-          <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+          <ul class="navbar-nav lg:justify-content-end lg:flex-grow-1 pe-3">
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="#">Home</a>
             </li>


### PR DESCRIPTION
### Description

Fixed an issue where the nav section of the Navbars-drawer was displayed at the bottom when the drawer was open.

### Motivation & Context

When you open the drawer on the https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/examples/navbars-drawer/ page at a mobile size, it looks like this:
<img width="490" height="895" alt="navber-drawer" src="https://github.com/user-attachments/assets/6c785ad5-3f1f-4155-b162-dbfa15917e0a" />
So, I’ve made some adjustments.
Since the top two elements always display in mobile view, I removed the flexbox class from them and applied the responsive class only to the bottom navigation bar.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42881--twbs-bootstrap.netlify.app/docs/6.0/examples/navbars-drawer/>

### Related issues

<!-- Please link any related issues here. -->
