### PR TITLE
Remove react-nextjs example from v6 docs

### DIFF
--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -21,10 +21,6 @@
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
       indexPath: src/index.html
-    - name: React
-      description: "Import and bundle Bootstrap's source Sass and JavaScript with React, Next.js, and React Bootstrap."
-      url: /examples/tree/main/react-nextjs
-      indexPath: src/pages/index.tsx
     - name: Vite
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
       url: /examples/tree/main/vite


### PR DESCRIPTION
## Summary

- Removes the React (`react-nextjs`) entry from the JS framework examples list (`site/data/examples.yml`), so it no longer appears on the v6 docs examples page.
- React Bootstrap has no Bootstrap v6-compatible release yet — its components render their own DOM, so pairing it with v6's CSS breaks styling entirely.
- The `react-nextjs` example itself was already dropped from twbs/examples' `v6-dev` branch for the same reason (twbs/examples#997). This keeps the docs listing consistent with what actually exists on that branch.
- The example stays available under Bootstrap 5 docs (`main`), which still points at `twbs/examples`'s `main` branch.
- Live preview at https://deploy-preview-42893--twbs-bootstrap.netlify.app/docs/6.0/examples/

🤖 Generated with [Claude Code](https://claude.com/claude-code)