### PR TITLE
Fix .table-responsive causing unexpected body scrollbar with visually…

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -164,6 +164,7 @@
 
   @include media-breakpoint-down($breakpoint) {
     .table-responsive#{$infix} {
+      position: relative;
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
     }


### PR DESCRIPTION
Fixes #41554

### Description

`.table-responsive` didn't establish its own positioning context. A `.visually-hidden` element (which is `position: absolute`) placed inside a scrolled `.table-responsive` wrapper (e.g. in a table header cell) had no positioned ancestor closer than the document, so its containing block effectively bubbled up past the wrapper. This caused Chrome to compute extra scrollable overflow on the document itself, producing an unexpected body-level scrollbar even though the table's own wrapper was already scrolling correctly.

This PR adds `position: relative` to `.table-responsive`, giving it its own containing block so absolutely positioned descendants (like `.visually-hidden` content) are contained by the wrapper instead of leaking into page-level layout.

### Motivation & Context

Reported in #41554: a horizontally scrolled, wide table with `.visually-hidden` text in the last column of the table head produces an unexpected body scrollbar in Chrome (not Firefox). Possibly related: #41790, where `.visually-hidden` on a `<table>` also takes up unexpected layout space in Safari/Chrome — likely the same underlying containing-block mechanism.

### Testing done

- Rebuilt the reporter's reduced test case locally, using Bootstrap's actual `.table-responsive` component, and confirmed the fix holds for the scenario described (wrapper scrolled fully, no document-level scrollbar).
- `npm run css-lint` passes.
- `npm run css-test` passes (46 specs, 0 failures).
- Manually checked the Tables documentation page for visual regressions — none found.
- Note for reviewers: I wasn't able to reproduce the original bug on the Chrome version available to me for local testing, so I could not directly confirm a before/after contrast myself. The fix is based on the containing-block mechanism described in the issue. Happy to have this verified against the original reporter's browser/version during review.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (using `npm run lint`)
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
