### PR TITLE
Use percentages for the navbar dark color-mix() weights

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -51,13 +51,13 @@ $navbar-tokens: defaults(
 // stylelint-disable-next-line scss/dollar-variable-default
 $navbar-dark-tokens: defaults(
   (
-    --navbar-color: color-mix(in oklch, var(--white) .55, transparent),
-    --navbar-hover-color: color-mix(in oklch, var(--white) .75, transparent),
-    --navbar-disabled-color: color-mix(in oklch, var(--white) .25, transparent),
+    --navbar-color: color-mix(in oklch, var(--white) 55%, transparent),
+    --navbar-hover-color: color-mix(in oklch, var(--white) 75%, transparent),
+    --navbar-disabled-color: color-mix(in oklch, var(--white) 25%, transparent),
     --navbar-active-color: var(--white),
     --navbar-brand-color: var(--white),
     --navbar-brand-hover-color: var(--white),
-    --navbar-toggler-border-color: color-mix(in oklch, var(--white) .1, transparent),
+    --navbar-toggler-border-color: color-mix(in oklch, var(--white) 10%, transparent),
   ),
   $navbar-dark-tokens
 );


### PR DESCRIPTION
- `color-mix()` needs a `<percentage>` as the mixing weight. Four `$navbar-dark-tokens` values pass a bare number instead, so `.navbar-dark` link colors are invalid at computed-value time and the element inherits its color.
- Nothing warns about it: a bare number is a valid custom property *declaration*, it only fails when `var()` substitutes it. That is why it survived review.
- The values came from the v5 `rgba($white, .55)` form in #41983 and kept the decimal. The other 28 `color-mix()` calls in the stylesheet already use percentages.
- `.55` → `55%`, `.75` → `75%`, `.25` → `25%`, `.1` → `10%`.

Checked in Chrome 148: with `.55` the probe inherits its parent's `rgb(255, 0, 0)`, with `55%` it computes `oklch(0.999994 0.0000497986 none / 0.55)`.

No dist in the diff.

Found while working on [julien-deramond/bootstrap-tokens#14](https://github.com/julien-deramond/bootstrap-tokens/issues/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)