### PR TITLE
Fix Dialog swap opening both dialogs on double-click

### DIFF
--- a/js/src/dialog.ts
+++ b/js/src/dialog.ts
@@ -143,6 +143,13 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   const shouldSwap = currentDialog && currentDialog !== target
 
   if (shouldSwap) {
+    // Ignore the trigger while the outgoing dialog is still transitioning in
+    // (marked by .dialog-swap-in). Otherwise a fast double-click opens the
+    // next dialog before the current one can hide, showing both at once.
+    if (currentDialog.classList.contains(CLASS_NAME_SWAP_IN)) {
+      return
+    }
+
     // Swap strategy (seamless backdrop, no flash):
     //   1. Mark the incoming dialog with .dialog-swap-in so its ::backdrop
     //      skips the @starting-style fade-in and appears fully opaque on

--- a/js/tests/unit/dialog.spec.js
+++ b/js/tests/unit/dialog.spec.js
@@ -954,6 +954,38 @@ describe('Dialog', () => {
         firstTrigger.click()
       })
     })
+
+    it('should not open both dialogs when a swap trigger is clicked mid-swap', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<button data-bs-toggle="dialog" data-bs-target="#dialog1">Open first</button>',
+          '<dialog id="dialog1" class="dialog">',
+          '  <button data-bs-toggle="dialog" data-bs-target="#dialog2">Go to second</button>',
+          '</dialog>',
+          '<dialog id="dialog2" class="dialog">',
+          '  <button data-bs-toggle="dialog" data-bs-target="#dialog1">Back to first</button>',
+          '</dialog>'
+        ].join('')
+
+        const dialog1El = fixtureEl.querySelector('#dialog1')
+        const dialog2El = fixtureEl.querySelector('#dialog2')
+        const firstTrigger = fixtureEl.querySelector('button[data-bs-target="#dialog1"]')
+        const swapTrigger = dialog1El.querySelector('[data-bs-target="#dialog2"]')
+        const backTrigger = dialog2El.querySelector('[data-bs-target="#dialog1"]')
+
+        dialog1El.addEventListener('shown.bs.dialog', () => {
+          // Swap to dialog2, then click its swap trigger before it settles.
+          swapTrigger.click()
+          backTrigger.click()
+
+          expect(dialog1El.open).toBeFalse()
+          expect(dialog2El.open).toBeTrue()
+          resolve()
+        })
+
+        firstTrigger.click()
+      })
+    })
   })
 
   describe('getInstance', () => {


### PR DESCRIPTION
### Description

A fast double-click on a dialog swap trigger opened both dialogs at once, with a layered/doubled backdrop. The second click hit the just-opened dialog's own swap trigger before its entry transition ended, so the outgoing dialog could not hide.

The swap now ignores a trigger while the outgoing dialog still has `.dialog-swap-in`, which marks an unfinished entry transition. Added a unit test.

### Motivation & Context

Only one dialog should show during a swap. Reported at https://github.com/twbs/bootstrap/discussions/42444#discussioncomment-18384037.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Related issues

Reported at https://github.com/twbs/bootstrap/discussions/42444#discussioncomment-18384037

🤖 Generated with [Claude Code](https://claude.com/claude-code)